### PR TITLE
Debug session interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ junit.xml
 *.tsbuildinfo
 
 yarn.lock
+
+# xeus-python debug logs
+xpython_debug_logs
+xeus.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,48 @@
 # @jupyterlab/debugger
+
 A JupyterLab debugger UI extension
 
 This extension is under active development and is not yet available.
+
+## Prerequisites
+
+- JupyterLab 1.1+
+
+## Development
+
+```bash
+# Create a new conda environment
+conda create -n jupyterlab-debugger -c conda-forge jupyterlab nodejs xeus-python ptvsd
+
+# Activate the conda environment
+conda activate jupyterlab-debugger
+
+# Create a directory for the kernel debug logs in the folder where JupyterLab is started
+mkdir xpython_debug_logs
+
+# Install dependencies
+jlpm
+
+# Build Typescript source
+jlpm build
+
+# Link your development version of the extension with JupyterLab
+jupyter labextension link .
+
+# Rebuild Typescript source after making changes
+jlpm build
+
+# Rebuild JupyterLab after making any changes
+jupyter lab build
+
+# Start JupyterLab with the kernel logs enabled and watch move enabled
+XEUS_LOG=1 jupyter lab --no-browser --watch
+```
+
+### Tests
+
+To run the tests:
+
+```bash
+jlpm run test
+```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ XEUS_LOG=1 jupyter lab --no-browser --watch
 
 ### Tests
 
+Make sure `xeus-python` is installed and `jupyter --paths` points to where the kernel is installed.
+
 To run the tests:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,5 +46,8 @@ Make sure `xeus-python` is installed and `jupyter --paths` points to where the k
 To run the tests:
 
 ```bash
+# [Optional] to enable the logs for xeus-python
+export XEUS_LOG=1
+
 jlpm run test
 ```

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "@jupyterlab/notebook": "^1.1.0-alpha.1",
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/disposable": "^1.2.0",
-    "@phosphor/widgets": "^1.8.0"
+    "@phosphor/widgets": "^1.8.0",
+    "vscode-debugprotocol": "1.35.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -39,14 +39,15 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.0.0",
-    "@jupyterlab/apputils": "^1.0.0",
-    "@jupyterlab/codeeditor": "^1.0.0",
-    "@jupyterlab/console": "^1.0.2",
-    "@jupyterlab/coreutils": "^3.0.0",
-    "@jupyterlab/fileeditor": "^1.0.2",
-    "@jupyterlab/launcher": "^1.0.0",
-    "@jupyterlab/notebook": "^1.0.0",
+    "@jupyterlab/application": "^1.1.0-alpha.1",
+    "@jupyterlab/apputils": "^1.1.0-alpha.1",
+    "@jupyterlab/codeeditor": "^1.1.0-alpha.1",
+    "@jupyterlab/console": "^1.1.0-alpha.1",
+    "@jupyterlab/coreutils": "^3.1.0-alpha.1",
+    "@jupyterlab/fileeditor": "^1.1.0-alpha.1",
+    "@jupyterlab/launcher": "^1.1.0-alpha.1",
+    "@jupyterlab/services": "^4.1.0-alpha.1",
+    "@jupyterlab/notebook": "^1.1.0-alpha.1",
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/disposable": "^1.2.0",
     "@phosphor/widgets": "^1.8.0"
@@ -54,7 +55,7 @@
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "@jupyterlab/testutils": "^1.0.2",
+    "@jupyterlab/testutils": "^1.1.0-alpha.1",
     "@types/chai": "^4.1.3",
     "@types/jest": "^24.0.17",
     "chai": "^4.2.0",

--- a/src/session.ts
+++ b/src/session.ts
@@ -85,23 +85,23 @@ export class DebugSession implements IDebugger.ISession {
    * @param command debug command.
    * @param args arguments for the debug command.
    */
-  async sendRequest<K extends keyof IDebugger.ISession.IRequest>(
+  async sendRequest<K extends keyof IDebugger.ISession.Request>(
     command: K,
-    args: IDebugger.ISession.IRequest[K]
-  ): Promise<IDebugger.ISession.IResponse[K]> {
+    args: IDebugger.ISession.Request[K]
+  ): Promise<IDebugger.ISession.Response[K]> {
     const message = await this._sendDebugMessage({
       type: 'request',
       seq: this._seq++,
       command,
       arguments: args
     });
-    return message.content as IDebugger.ISession.IResponse[K];
+    return message.content as IDebugger.ISession.Response[K];
   }
 
   /**
    * Signal emitted for debug event messages.
    */
-  get eventMessage(): ISignal<DebugSession, IDebugger.ISession.IEvent> {
+  get eventMessage(): ISignal<DebugSession, IDebugger.ISession.Event> {
     return this._eventMessage;
   }
 
@@ -116,7 +116,7 @@ export class DebugSession implements IDebugger.ISession {
     if (msgType !== 'debug_event') {
       return;
     }
-    const event = message.content as IDebugger.ISession.IEvent;
+    const event = message.content as IDebugger.ISession.Event;
     this._eventMessage.emit(event);
   }
 
@@ -143,7 +143,7 @@ export class DebugSession implements IDebugger.ISession {
   private _disposed = new Signal<this, void>(this);
   private _isDisposed: boolean = false;
 
-  private _eventMessage = new Signal<DebugSession, IDebugger.ISession.IEvent>(
+  private _eventMessage = new Signal<DebugSession, IDebugger.ISession.Event>(
     this
   );
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -25,15 +25,25 @@ export class DebugSession implements IDebugger.ISession {
   }
 
   /**
+   * The client session to connect to a debugger.
+   */
+  client: IClientSession;
+
+  /**
+   * The code editors in a debugger session.
+   */
+  editors: CodeEditor.IEditor[];
+
+  /**
    * Dispose the debug session.
    */
   dispose(): void {
     if (this.isDisposed) {
       return;
     }
-    this.client.iopubMessage.disconnect(this._handleEvent, this);
     this._isDisposed = true;
     this._disposed.emit();
+    Signal.clearData(this);
   }
 
   /**
@@ -53,7 +63,7 @@ export class DebugSession implements IDebugger.ISession {
   /**
    * Start a new debug session
    */
-  public async start(): Promise<void> {
+  async start(): Promise<void> {
     await this.sendRequest('initialize', {
       clientID: 'jupyterlab',
       clientName: 'JupyterLab',
@@ -73,7 +83,7 @@ export class DebugSession implements IDebugger.ISession {
   /**
    * Stop the running debug session.
    */
-  public async stop(): Promise<void> {
+  async stop(): Promise<void> {
     await this.sendRequest('disconnect', {
       restart: false,
       terminateDebuggee: true
@@ -137,19 +147,11 @@ export class DebugSession implements IDebugger.ISession {
     return reply.promise;
   }
 
-  client: IClientSession;
-  editors: CodeEditor.IEditor[];
-
   private _disposed = new Signal<this, void>(this);
   private _isDisposed: boolean = false;
-
   private _eventMessage = new Signal<DebugSession, IDebugger.ISession.Event>(
     this
   );
-
-  /**
-   * Debug protocol sequence number.
-   */
   private _seq: number = 0;
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -102,7 +102,7 @@ export class DebugSession implements IDebugger.ISession {
    * Send a debug request message to the kernel.
    * @param msg debug request message to send to the kernel.
    */
-  public async _sendDebugMessage(
+  private async _sendDebugMessage(
     msg: KernelMessage.IDebugRequestMsg['content']
   ): Promise<KernelMessage.IDebugReplyMsg> {
     const reply = new PromiseDelegate<KernelMessage.IDebugReplyMsg>();

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,7 +2,13 @@ import { IClientSession } from '@jupyterlab/apputils';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
+import { KernelMessage } from '@jupyterlab/services';
+
+import { PromiseDelegate } from '@phosphor/coreutils';
+
 import { ISignal, Signal } from '@phosphor/signaling';
+
+import { DebugProtocol } from 'vscode-debugprotocol';
 
 import { IDebugger } from './tokens';
 
@@ -41,8 +47,72 @@ export class DebugSession implements IDebugger.ISession {
     return this._isDisposed;
   }
 
-  async start(): Promise<void> {
-    return void 0;
+  /**
+   * Start a new debug session
+   */
+  public async start(): Promise<void> {
+    await this.sendRequest('initialize', {
+      clientID: 'jupyterlab',
+      clientName: 'JupyterLab',
+      adapterID: 'python',
+      pathFormat: 'path',
+      linesStartAt1: true,
+      columnsStartAt1: true,
+      supportsVariableType: true,
+      supportsVariablePaging: true,
+      supportsRunInTerminalRequest: true,
+      locale: 'en-us'
+    });
+
+    await this.sendRequest('attach', {});
+  }
+
+  /**
+   * Stop the running debug session.
+   */
+  public async stop(): Promise<void> {
+    await this.sendRequest('disconnect', {
+      restart: false,
+      terminateDebuggee: true
+    });
+  }
+
+  /**
+   * Send a custom debug request to the kernel.
+   * @param command debug command.
+   * @param args arguments for the debug command.
+   */
+  async sendRequest<K extends keyof DebugSession.IDebugRequestTypes>(
+    command: K,
+    args: DebugSession.IDebugRequestTypes[K]
+  ): Promise<DebugSession.IDebugResponseTypes[K]> {
+    const message = await this._sendDebugMessage({
+      type: 'request',
+      seq: this._seq++,
+      command,
+      arguments: args
+    });
+    return message.content as DebugSession.IDebugResponseTypes[K];
+  }
+
+  /**
+   * Send a debug request message to the kernel.
+   * @param msg debug request message to send to the kernel.
+   */
+  public async _sendDebugMessage(
+    msg: KernelMessage.IDebugRequestMsg['content']
+  ): Promise<KernelMessage.IDebugReplyMsg> {
+    const reply = new PromiseDelegate<KernelMessage.IDebugReplyMsg>();
+    const kernel = this.client.kernel;
+    const future = kernel.requestDebug(msg);
+    future.onReply = (msg: KernelMessage.IDebugReplyMsg) => {
+      if (!msg.content.success) {
+        return reply.reject(msg);
+      }
+      return reply.resolve(msg);
+    };
+    await future.done;
+    return reply.promise;
   }
 
   client: IClientSession;
@@ -50,6 +120,11 @@ export class DebugSession implements IDebugger.ISession {
 
   private _disposed = new Signal<this, void>(this);
   private _isDisposed: boolean = false;
+
+  /**
+   * Debug protocol sequence number.
+   */
+  private _seq: number = 0;
 }
 
 /**
@@ -61,5 +136,84 @@ export namespace DebugSession {
      * The client session used by the debug session.
      */
     client: IClientSession;
+  }
+
+  /**
+   * Interface for all the debug requests types.
+   */
+  export interface IDebugRequestTypes {
+    attach: DebugProtocol.AttachRequestArguments;
+    completions: DebugProtocol.CompletionsArguments;
+    configurationDone: DebugProtocol.ConfigurationDoneArguments;
+    continue: DebugProtocol.ContinueArguments;
+    disconnect: DebugProtocol.DisconnectArguments;
+    evaluate: DebugProtocol.EvaluateArguments;
+    exceptionInfo: DebugProtocol.ExceptionInfoArguments;
+    goto: DebugProtocol.GotoArguments;
+    gotoTargets: DebugProtocol.GotoTargetsArguments;
+    initialize: DebugProtocol.InitializeRequestArguments;
+    launch: DebugProtocol.LaunchRequestArguments;
+    loadedSources: DebugProtocol.LoadedSourcesArguments;
+    modules: DebugProtocol.ModulesArguments;
+    next: DebugProtocol.NextArguments;
+    pause: DebugProtocol.PauseArguments;
+    restart: DebugProtocol.RestartArguments;
+    restartFrame: DebugProtocol.RestartFrameArguments;
+    reverseContinue: DebugProtocol.ReverseContinueArguments;
+    scopes: DebugProtocol.ScopesArguments;
+    setBreakpoints: DebugProtocol.SetBreakpointsArguments;
+    setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsArguments;
+    setExpression: DebugProtocol.SetExpressionArguments;
+    setFunctionBreakpoints: DebugProtocol.SetFunctionBreakpointsArguments;
+    setVariable: DebugProtocol.SetVariableArguments;
+    source: DebugProtocol.SourceArguments;
+    stackTrace: DebugProtocol.StackTraceArguments;
+    stepBack: DebugProtocol.StepBackArguments;
+    stepIn: DebugProtocol.StepInArguments;
+    stepInTargets: DebugProtocol.StepInTargetsArguments;
+    stepOut: DebugProtocol.StepOutArguments;
+    terminate: DebugProtocol.TerminateArguments;
+    terminateThreads: DebugProtocol.TerminateThreadsArguments;
+    threads: {};
+  }
+
+  /**
+   * Interface for all the debug response types.
+   */
+  export interface IDebugResponseTypes {
+    attach: DebugProtocol.AttachResponse;
+    completions: DebugProtocol.CompletionsResponse;
+    configurationDone: DebugProtocol.ConfigurationDoneResponse;
+    continue: DebugProtocol.ContinueResponse;
+    disconnect: DebugProtocol.DisconnectResponse;
+    evaluate: DebugProtocol.EvaluateResponse;
+    exceptionInfo: DebugProtocol.ExceptionInfoResponse;
+    goto: DebugProtocol.GotoResponse;
+    gotoTargets: DebugProtocol.GotoTargetsResponse;
+    initialize: DebugProtocol.InitializeResponse;
+    launch: DebugProtocol.LaunchResponse;
+    loadedSources: DebugProtocol.LoadedSourcesResponse;
+    modules: DebugProtocol.ModulesResponse;
+    next: DebugProtocol.NextResponse;
+    pause: DebugProtocol.PauseResponse;
+    restart: DebugProtocol.RestartResponse;
+    restartFrame: DebugProtocol.RestartFrameResponse;
+    reverseContinue: DebugProtocol.ReverseContinueResponse;
+    scopes: DebugProtocol.ScopesResponse;
+    setBreakpoints: DebugProtocol.SetBreakpointsResponse;
+    setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsResponse;
+    setExpression: DebugProtocol.SetExpressionResponse;
+    setFunctionBreakpoints: DebugProtocol.SetFunctionBreakpointsResponse;
+    setVariable: DebugProtocol.SetVariableResponse;
+    source: DebugProtocol.SourceResponse;
+    stackTrace: DebugProtocol.StackTraceResponse;
+    stepBack: DebugProtocol.StepBackResponse;
+    stepIn: DebugProtocol.StepInResponse;
+    stepInTargets: DebugProtocol.StepInTargetsResponse;
+    stepOut: DebugProtocol.StepOutResponse;
+    terminate: DebugProtocol.TerminateResponse;
+    terminateThreads: DebugProtocol.TerminateThreadsResponse;
+    threads: DebugProtocol.ThreadsResponse;
+    variables: DebugProtocol.VariablesResponse;
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -41,6 +41,10 @@ export class DebugSession implements IDebugger.ISession {
     return this._isDisposed;
   }
 
+  async start(): Promise<void> {
+    return void 0;
+  }
+
   client: IClientSession;
   editors: CodeEditor.IEditor[];
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -173,8 +173,10 @@ export namespace DebugSession {
     code: string;
   }
 
-  export interface IUpdateCellResponse {
-    sourcePath: string;
+  export interface IUpdateCellResponse extends DebugProtocol.Response {
+    body: {
+      sourcePath: string;
+    };
   }
 
   /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,61 @@
+import { IClientSession } from '@jupyterlab/apputils';
+
+import { CodeEditor } from '@jupyterlab/codeeditor';
+
+import { ISignal, Signal } from '@phosphor/signaling';
+
+import { IDebugger } from './tokens';
+
+export class DebugSession implements IDebugger.ISession {
+  /**
+   * Instantiate a new debug session
+   *
+   * @param options - The debug session instantiation options.
+   */
+  constructor(options: DebugSession.IOptions) {
+    this.client = options.client;
+  }
+
+  /**
+   * Dispose the debug session.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this._disposed.emit();
+  }
+
+  /**
+   * A signal emitted when the debug session is disposed.
+   */
+  get disposed(): ISignal<this, void> {
+    return this._disposed;
+  }
+
+  /**
+   * Whether the debug session is disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  client: IClientSession;
+  editors: CodeEditor.IEditor[];
+
+  private _disposed = new Signal<this, void>(this);
+  private _isDisposed: boolean = false;
+}
+
+/**
+ * A namespace for `DebugSession` statics.
+ */
+export namespace DebugSession {
+  export interface IOptions {
+    /**
+     * The client session used by the debug session.
+     */
+    client: IClientSession;
+  }
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,8 +11,6 @@ import { PromiseDelegate } from '@phosphor/coreutils';
 
 import { ISignal, Signal } from '@phosphor/signaling';
 
-import { DebugProtocol } from 'vscode-debugprotocol';
-
 import { IDebugger } from './tokens';
 
 export class DebugSession implements IDebugger.ISession {
@@ -87,23 +85,23 @@ export class DebugSession implements IDebugger.ISession {
    * @param command debug command.
    * @param args arguments for the debug command.
    */
-  async sendRequest<K extends keyof DebugSession.IDebugRequestTypes>(
+  async sendRequest<K extends keyof IDebugger.ISession.IRequest>(
     command: K,
-    args: DebugSession.IDebugRequestTypes[K]
-  ): Promise<DebugSession.IDebugResponseTypes[K]> {
+    args: IDebugger.ISession.IRequest[K]
+  ): Promise<IDebugger.ISession.IResponse[K]> {
     const message = await this._sendDebugMessage({
       type: 'request',
       seq: this._seq++,
       command,
       arguments: args
     });
-    return message.content as DebugSession.IDebugResponseTypes[K];
+    return message.content as IDebugger.ISession.IResponse[K];
   }
 
   /**
    * Signal emitted for debug event messages.
    */
-  get eventMessage(): ISignal<DebugSession, DebugProtocol.Event> {
+  get eventMessage(): ISignal<DebugSession, IDebugger.ISession.IEvent> {
     return this._eventMessage;
   }
 
@@ -118,7 +116,7 @@ export class DebugSession implements IDebugger.ISession {
     if (msgType !== 'debug_event') {
       return;
     }
-    const event = message.content as DebugProtocol.Event;
+    const event = message.content as IDebugger.ISession.IEvent;
     this._eventMessage.emit(event);
   }
 
@@ -145,7 +143,9 @@ export class DebugSession implements IDebugger.ISession {
   private _disposed = new Signal<this, void>(this);
   private _isDisposed: boolean = false;
 
-  private _eventMessage = new Signal<DebugSession, DebugProtocol.Event>(this);
+  private _eventMessage = new Signal<DebugSession, IDebugger.ISession.IEvent>(
+    this
+  );
 
   /**
    * Debug protocol sequence number.
@@ -162,98 +162,5 @@ export namespace DebugSession {
      * The client session used by the debug session.
      */
     client: IClientSession;
-  }
-
-  export interface IUpdateCellArguments {
-    cellId: number;
-    nextId: number;
-    code: string;
-  }
-
-  export interface IUpdateCellResponse extends DebugProtocol.Response {
-    body: {
-      sourcePath: string;
-    };
-  }
-
-  /**
-   * Interface for all the debug requests types.
-   */
-  export interface IDebugRequestTypes {
-    attach: DebugProtocol.AttachRequestArguments;
-    completions: DebugProtocol.CompletionsArguments;
-    configurationDone: DebugProtocol.ConfigurationDoneArguments;
-    continue: DebugProtocol.ContinueArguments;
-    disconnect: DebugProtocol.DisconnectArguments;
-    evaluate: DebugProtocol.EvaluateArguments;
-    exceptionInfo: DebugProtocol.ExceptionInfoArguments;
-    goto: DebugProtocol.GotoArguments;
-    gotoTargets: DebugProtocol.GotoTargetsArguments;
-    initialize: DebugProtocol.InitializeRequestArguments;
-    launch: DebugProtocol.LaunchRequestArguments;
-    loadedSources: DebugProtocol.LoadedSourcesArguments;
-    modules: DebugProtocol.ModulesArguments;
-    next: DebugProtocol.NextArguments;
-    pause: DebugProtocol.PauseArguments;
-    restart: DebugProtocol.RestartArguments;
-    restartFrame: DebugProtocol.RestartFrameArguments;
-    reverseContinue: DebugProtocol.ReverseContinueArguments;
-    scopes: DebugProtocol.ScopesArguments;
-    setBreakpoints: DebugProtocol.SetBreakpointsArguments;
-    setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsArguments;
-    setExpression: DebugProtocol.SetExpressionArguments;
-    setFunctionBreakpoints: DebugProtocol.SetFunctionBreakpointsArguments;
-    setVariable: DebugProtocol.SetVariableArguments;
-    source: DebugProtocol.SourceArguments;
-    stackTrace: DebugProtocol.StackTraceArguments;
-    stepBack: DebugProtocol.StepBackArguments;
-    stepIn: DebugProtocol.StepInArguments;
-    stepInTargets: DebugProtocol.StepInTargetsArguments;
-    stepOut: DebugProtocol.StepOutArguments;
-    terminate: DebugProtocol.TerminateArguments;
-    terminateThreads: DebugProtocol.TerminateThreadsArguments;
-    threads: {};
-    updateCell: IUpdateCellArguments;
-  }
-
-  /**
-   * Interface for all the debug response types.
-   */
-  export interface IDebugResponseTypes {
-    attach: DebugProtocol.AttachResponse;
-    completions: DebugProtocol.CompletionsResponse;
-    configurationDone: DebugProtocol.ConfigurationDoneResponse;
-    continue: DebugProtocol.ContinueResponse;
-    disconnect: DebugProtocol.DisconnectResponse;
-    evaluate: DebugProtocol.EvaluateResponse;
-    exceptionInfo: DebugProtocol.ExceptionInfoResponse;
-    goto: DebugProtocol.GotoResponse;
-    gotoTargets: DebugProtocol.GotoTargetsResponse;
-    initialize: DebugProtocol.InitializeResponse;
-    launch: DebugProtocol.LaunchResponse;
-    loadedSources: DebugProtocol.LoadedSourcesResponse;
-    modules: DebugProtocol.ModulesResponse;
-    next: DebugProtocol.NextResponse;
-    pause: DebugProtocol.PauseResponse;
-    restart: DebugProtocol.RestartResponse;
-    restartFrame: DebugProtocol.RestartFrameResponse;
-    reverseContinue: DebugProtocol.ReverseContinueResponse;
-    scopes: DebugProtocol.ScopesResponse;
-    setBreakpoints: DebugProtocol.SetBreakpointsResponse;
-    setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsResponse;
-    setExpression: DebugProtocol.SetExpressionResponse;
-    setFunctionBreakpoints: DebugProtocol.SetFunctionBreakpointsResponse;
-    setVariable: DebugProtocol.SetVariableResponse;
-    source: DebugProtocol.SourceResponse;
-    stackTrace: DebugProtocol.StackTraceResponse;
-    stepBack: DebugProtocol.StepBackResponse;
-    stepIn: DebugProtocol.StepInResponse;
-    stepInTargets: DebugProtocol.StepInTargetsResponse;
-    stepOut: DebugProtocol.StepOutResponse;
-    terminate: DebugProtocol.TerminateResponse;
-    terminateThreads: DebugProtocol.TerminateThreadsResponse;
-    threads: DebugProtocol.ThreadsResponse;
-    updateCell: IUpdateCellResponse;
-    variables: DebugProtocol.VariablesResponse;
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -167,6 +167,16 @@ export namespace DebugSession {
     client: IClientSession;
   }
 
+  export interface IUpdateCellArguments {
+    cellId: number;
+    nextId: number;
+    code: string;
+  }
+
+  export interface IUpdateCellResponse {
+    sourcePath: string;
+  }
+
   /**
    * Interface for all the debug requests types.
    */
@@ -204,6 +214,7 @@ export namespace DebugSession {
     terminate: DebugProtocol.TerminateArguments;
     terminateThreads: DebugProtocol.TerminateThreadsArguments;
     threads: {};
+    updateCell: IUpdateCellArguments;
   }
 
   /**
@@ -243,6 +254,7 @@ export namespace DebugSession {
     terminate: DebugProtocol.TerminateResponse;
     terminateThreads: DebugProtocol.TerminateThreadsResponse;
     threads: DebugProtocol.ThreadsResponse;
+    updateCell: IUpdateCellResponse;
     variables: DebugProtocol.VariablesResponse;
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -133,9 +133,6 @@ export class DebugSession implements IDebugger.ISession {
     const kernel = this.client.kernel;
     const future = kernel.requestDebug(msg);
     future.onReply = (msg: KernelMessage.IDebugReplyMsg) => {
-      if (!msg.content.success) {
-        return reply.reject(msg);
-      }
       return reply.resolve(msg);
     };
     await future.done;

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 import { IClientSession } from '@jupyterlab/apputils';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -37,6 +37,26 @@ export namespace IDebugger {
      * The code editors in a debugger session.
      */
     editors: CodeEditor.IEditor[];
+
+    /**
+     * Start a new debug session
+     */
+    start(): void;
+
+    /**
+     * Stop a running new debug session
+     */
+    stop(): void;
+  }
+
+  /**
+   * A visual debugger client.
+   */
+  export interface IClient extends IObservableDisposable {
+    /**
+     * The debug session.
+     */
+    session: ISession;
   }
 }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -75,9 +75,9 @@ export namespace IDebugger {
     }
 
     /**
-     * Interface for all the debug requests types.
+     * Expose all the debug requests types.
      */
-    export interface IRequest {
+    export type Request = {
       attach: DebugProtocol.AttachRequestArguments;
       completions: DebugProtocol.CompletionsArguments;
       configurationDone: DebugProtocol.ConfigurationDoneArguments;
@@ -112,12 +112,12 @@ export namespace IDebugger {
       terminateThreads: DebugProtocol.TerminateThreadsArguments;
       threads: {};
       updateCell: IUpdateCellArguments;
-    }
+    };
 
     /**
-     * Interface for all the debug response types.
+     * Expose all the debug response types.
      */
-    export interface IResponse {
+    export type Response = {
       attach: DebugProtocol.AttachResponse;
       completions: DebugProtocol.CompletionsResponse;
       configurationDone: DebugProtocol.ConfigurationDoneResponse;
@@ -153,12 +153,12 @@ export namespace IDebugger {
       threads: DebugProtocol.ThreadsResponse;
       updateCell: IUpdateCellResponse;
       variables: DebugProtocol.VariablesResponse;
-    }
+    };
 
     /**
      * A generic debug event.
      */
-    export type IEvent = DebugProtocol.Event;
+    export type Event = DebugProtocol.Event;
   }
 }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -48,16 +48,6 @@ export namespace IDebugger {
      */
     stop(): void;
   }
-
-  /**
-   * A visual debugger client.
-   */
-  export interface IClient extends IObservableDisposable {
-    /**
-     * The debug session.
-     */
-    session: ISession;
-  }
 }
 
 /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -18,8 +18,7 @@ import { Debugger } from './debugger';
 /**
  * An interface describing an application's visual debugger.
  */
-export interface IDebugger
-  extends IWidgetTracker<MainAreaWidget<Debugger>> {}
+export interface IDebugger extends IWidgetTracker<MainAreaWidget<Debugger>> {}
 
 /**
  * A namespace for visual debugger types.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -13,6 +13,8 @@ import { Token } from '@phosphor/coreutils';
 
 import { IObservableDisposable } from '@phosphor/disposable';
 
+import { DebugProtocol } from 'vscode-debugprotocol';
+
 import { Debugger } from './debugger';
 
 /**
@@ -39,14 +41,124 @@ export namespace IDebugger {
     editors: CodeEditor.IEditor[];
 
     /**
-     * Start a new debug session
+     * Start a new debug session.
      */
     start(): void;
 
     /**
-     * Stop a running new debug session
+     * Stop a running debug session.
      */
     stop(): void;
+  }
+
+  export namespace ISession {
+    /**
+     * Arguments for 'updateCell' request.
+     * This is an addition to the Debug Adapter Protocol to support
+     * setting breakpoints for cells
+     */
+    export interface IUpdateCellArguments {
+      cellId: number;
+      nextId: number;
+      code: string;
+    }
+
+    /**
+     * Response to 'updateCell' request.
+     * This is an addition to the Debug Adapter Protocol to support
+     * setting breakpoints for cells
+     */
+    export interface IUpdateCellResponse extends DebugProtocol.Response {
+      body: {
+        sourcePath: string;
+      };
+    }
+
+    /**
+     * Interface for all the debug requests types.
+     */
+    export interface IRequest {
+      attach: DebugProtocol.AttachRequestArguments;
+      completions: DebugProtocol.CompletionsArguments;
+      configurationDone: DebugProtocol.ConfigurationDoneArguments;
+      continue: DebugProtocol.ContinueArguments;
+      disconnect: DebugProtocol.DisconnectArguments;
+      evaluate: DebugProtocol.EvaluateArguments;
+      exceptionInfo: DebugProtocol.ExceptionInfoArguments;
+      goto: DebugProtocol.GotoArguments;
+      gotoTargets: DebugProtocol.GotoTargetsArguments;
+      initialize: DebugProtocol.InitializeRequestArguments;
+      launch: DebugProtocol.LaunchRequestArguments;
+      loadedSources: DebugProtocol.LoadedSourcesArguments;
+      modules: DebugProtocol.ModulesArguments;
+      next: DebugProtocol.NextArguments;
+      pause: DebugProtocol.PauseArguments;
+      restart: DebugProtocol.RestartArguments;
+      restartFrame: DebugProtocol.RestartFrameArguments;
+      reverseContinue: DebugProtocol.ReverseContinueArguments;
+      scopes: DebugProtocol.ScopesArguments;
+      setBreakpoints: DebugProtocol.SetBreakpointsArguments;
+      setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsArguments;
+      setExpression: DebugProtocol.SetExpressionArguments;
+      setFunctionBreakpoints: DebugProtocol.SetFunctionBreakpointsArguments;
+      setVariable: DebugProtocol.SetVariableArguments;
+      source: DebugProtocol.SourceArguments;
+      stackTrace: DebugProtocol.StackTraceArguments;
+      stepBack: DebugProtocol.StepBackArguments;
+      stepIn: DebugProtocol.StepInArguments;
+      stepInTargets: DebugProtocol.StepInTargetsArguments;
+      stepOut: DebugProtocol.StepOutArguments;
+      terminate: DebugProtocol.TerminateArguments;
+      terminateThreads: DebugProtocol.TerminateThreadsArguments;
+      threads: {};
+      updateCell: IUpdateCellArguments;
+    }
+
+    /**
+     * Interface for all the debug response types.
+     */
+    export interface IResponse {
+      attach: DebugProtocol.AttachResponse;
+      completions: DebugProtocol.CompletionsResponse;
+      configurationDone: DebugProtocol.ConfigurationDoneResponse;
+      continue: DebugProtocol.ContinueResponse;
+      disconnect: DebugProtocol.DisconnectResponse;
+      evaluate: DebugProtocol.EvaluateResponse;
+      exceptionInfo: DebugProtocol.ExceptionInfoResponse;
+      goto: DebugProtocol.GotoResponse;
+      gotoTargets: DebugProtocol.GotoTargetsResponse;
+      initialize: DebugProtocol.InitializeResponse;
+      launch: DebugProtocol.LaunchResponse;
+      loadedSources: DebugProtocol.LoadedSourcesResponse;
+      modules: DebugProtocol.ModulesResponse;
+      next: DebugProtocol.NextResponse;
+      pause: DebugProtocol.PauseResponse;
+      restart: DebugProtocol.RestartResponse;
+      restartFrame: DebugProtocol.RestartFrameResponse;
+      reverseContinue: DebugProtocol.ReverseContinueResponse;
+      scopes: DebugProtocol.ScopesResponse;
+      setBreakpoints: DebugProtocol.SetBreakpointsResponse;
+      setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsResponse;
+      setExpression: DebugProtocol.SetExpressionResponse;
+      setFunctionBreakpoints: DebugProtocol.SetFunctionBreakpointsResponse;
+      setVariable: DebugProtocol.SetVariableResponse;
+      source: DebugProtocol.SourceResponse;
+      stackTrace: DebugProtocol.StackTraceResponse;
+      stepBack: DebugProtocol.StepBackResponse;
+      stepIn: DebugProtocol.StepInResponse;
+      stepInTargets: DebugProtocol.StepInTargetsResponse;
+      stepOut: DebugProtocol.StepOutResponse;
+      terminate: DebugProtocol.TerminateResponse;
+      terminateThreads: DebugProtocol.TerminateThreadsResponse;
+      threads: DebugProtocol.ThreadsResponse;
+      updateCell: IUpdateCellResponse;
+      variables: DebugProtocol.VariablesResponse;
+    }
+
+    /**
+     * A generic debug event.
+     */
+    export type IEvent = DebugProtocol.Event;
   }
 }
 

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -1,13 +1,27 @@
-module.exports = {
-  preset: "ts-jest/presets/js-with-babel",
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-  transformIgnorePatterns: ["/node_modules/(?!(@jupyterlab/.*)/)"],
+const func = require('@jupyterlab/testutils/lib/jest-config');
+const upstream = func('@jupyterlab/debugger', __dirname);
+
+let local = {
+  preset: 'ts-jest/presets/js-with-babel',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  transformIgnorePatterns: ['/node_modules/(?!(@jupyterlab/.*)/)'],
   globals: {
-    "ts-jest": {
-      tsConfig: "./tsconfig.json"
+    'ts-jest': {
+      tsConfig: './tsconfig.json'
     }
   },
   transform: {
-    "\\.(ts|tsx)?$": "ts-jest"
+    '\\.(ts|tsx)?$': 'ts-jest'
   }
 };
+
+[
+  'moduleNameMapper',
+  'setupFilesAfterEnv',
+  'setupFiles',
+  'moduleFileExtensions'
+].forEach(option => {
+  local[option] = upstream[option];
+});
+
+module.exports = local;

--- a/tests/run-test.py
+++ b/tests/run-test.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import os
 from jupyterlab.tests.test_app import run_jest, JestApp
 

--- a/tests/run-test.py
+++ b/tests/run-test.py
@@ -1,7 +1,11 @@
 import os
-from jupyterlab.tests.test_app import run_jest
+from jupyterlab.tests.test_app import run_jest, JestApp
 
 HERE = os.path.realpath(os.path.dirname(__file__))
 
 if __name__ == '__main__':
+    # xeus-python requires the xpython_debug_logs folder
+    jest_app = JestApp.instance()
+    os.mkdir(os.path.join(jest_app.notebook_dir, 'xpython_debug_logs'))
+
     run_jest(HERE)

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -12,10 +12,7 @@ describe('DebugSession', () => {
   beforeEach(async () => {
     client = await createClientSession({
       kernelPreference: {
-        name: 'python3', // TODO: replace by xpython
-        language: 'python',
-        shouldStart: true,
-        canStart: true
+        name: 'xpython'
       }
     });
     await (client as ClientSession).initialize();

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -38,8 +38,13 @@ describe('DebugSession', () => {
   describe('#start() and #stop()', () => {
     it('should start and stop new debug session', async () => {
       const debugSession = new DebugSession({ client });
+      let events: string[] = [];
+      debugSession.eventMessage.connect((sender, event) => {
+        events.push(event.event);
+      });
       await debugSession.start();
       await debugSession.stop();
+      expect(events).to.deep.equal(['output', 'initialized', 'process']);
     });
   });
 });

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -32,10 +32,11 @@ describe('DebugSession', () => {
     });
   });
 
-  describe('#start()', () => {
-    it('should start a new debug session', async () => {
+  describe('#start() and #stop()', () => {
+    it('should start and stop new debug session', async () => {
       const debugSession = new DebugSession({ client });
       await debugSession.start();
+      await debugSession.stop();
     });
   });
 });

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -10,7 +10,14 @@ describe('DebugSession', () => {
   let client: IClientSession;
 
   beforeEach(async () => {
-    client = await createClientSession();
+    client = await createClientSession({
+      kernelPreference: {
+        name: 'python3', // TODO: replace by xpython
+        language: 'python',
+        shouldStart: true,
+        canStart: true
+      }
+    });
     await (client as ClientSession).initialize();
     await client.kernel.ready;
   });
@@ -25,6 +32,13 @@ describe('DebugSession', () => {
       expect(debugSession.isDisposed).to.equal(false);
       debugSession.dispose();
       expect(debugSession.isDisposed).to.equal(true);
+    });
+  });
+
+  describe('#start()', () => {
+    it('should start a new debug session', async () => {
+      const debugSession = new DebugSession({ client });
+      await debugSession.start();
     });
   });
 });

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -47,4 +47,37 @@ describe('DebugSession', () => {
       expect(events).to.deep.equal(['output', 'initialized', 'process']);
     });
   });
+
+  describe('#sendRequest', () => {
+    let debugSession: DebugSession;
+
+    beforeEach(async () => {
+      debugSession = new DebugSession({ client });
+      await debugSession.start();
+    });
+
+    afterEach(async () => {
+      await debugSession.stop();
+      debugSession.dispose();
+    });
+
+    it('should send debug messages to the kernel', async () => {
+      const code = 'i=0\ni+=1\ni+=1';
+      const reply = await debugSession.sendRequest('updateCell', {
+        cellId: 0,
+        nextId: 1,
+        code
+      });
+      expect(reply.body.sourcePath).to.contain('.py');
+    });
+
+    it('should handle replies with success false', async () => {
+      const reply = await debugSession.sendRequest('evaluate', {
+        expression: 'a'
+      });
+      const { success, message } = reply;
+      expect(success).to.be.false;
+      expect(message).to.contain('Unable to find thread for evaluation');
+    });
+  });
 });

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 import { expect } from 'chai';
 
 import { ClientSession, IClientSession } from '@jupyterlab/apputils';

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+
+import { ClientSession, IClientSession } from '@jupyterlab/apputils';
+
+import { createClientSession } from '@jupyterlab/testutils';
+
+import { DebugSession } from '../../lib/session';
+
+describe('DebugSession', () => {
+  let client: IClientSession;
+
+  beforeEach(async () => {
+    client = await createClientSession();
+    await (client as ClientSession).initialize();
+    await client.kernel.ready;
+  });
+
+  afterEach(async () => {
+    await client.shutdown();
+  });
+
+  describe('#isDisposed', () => {
+    it('should return whether the object is disposed', () => {
+      const debugSession = new DebugSession({ client });
+      expect(debugSession.isDisposed).to.equal(false);
+      debugSession.dispose();
+      expect(debugSession.isDisposed).to.equal(true);
+    });
+  });
+});

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -35,8 +35,8 @@ describe('DebugSession', () => {
     });
   });
 
-  describe('#start() and #stop()', () => {
-    it('should start and stop new debug session', async () => {
+  describe('#eventMessage', () => {
+    it('should be emitted when sending debug messages', async () => {
       const debugSession = new DebugSession({ client });
       let events: string[] = [];
       debugSession.eventMessage.connect((sender, event) => {


### PR DESCRIPTION
Provide a simple `DebugSession` interface that can be used to send debug messages to the kernel.

### TODO

- [x] Add `DebugSession`
- [x] Use `xpython` as `kernelPreference`
- [x] Implement `start` method
- [x] Implement `stop` method
