### PR TITLE
Add configuration for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,43 @@
+pool:
+  vmImage: 'ubuntu-16.04'
+
+strategy:
+  matrix:
+    Tests:
+      python.version: '3.7'
+      testResultsFiles: 'tests/**/junit.xml'
+
+steps:
+- bash: echo "##vso[task.prependpath]$CONDA/bin"
+  displayName: Add conda to PATH
+
+- bash: conda create --yes --quiet --name jupyterlab-debugger
+  displayName: Create a new conda environment
+
+- bash: |
+    source activate jupyterlab-debugger
+    conda install --yes --quiet -c conda-forge nodejs xeus-python ptvsd python=$PYTHON_VERSION
+    python -m pip install -U --pre jupyterlab
+  displayName: Install dependencies
+
+- bash: |
+    source activate jupyterlab-debugger
+    jlpm
+    jlpm run build
+  displayName: Build jupyterlab-debugger
+
+- bash: |
+    source activate jupyterlab-debugger
+    export JUPYTER_PATH=${CONDA_PREFIX}/share/jupyter
+    export XEUS_LOG=1
+    jlpm run test
+  displayName: Run the tests
+
+- task: PublishTestResults@2
+  displayName: 'Publish test results'
+  condition: variables['testResultsFiles']
+  inputs:
+    testResultsFiles: '$(testResultsFiles)'
+    testRunTitle: '$(group)'
+    mergeTestResults: true
+

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "chai": "^4.2.0",
     "husky": "^3.0.2",
     "jest": "^24.8.0",
+    "jest-junit": "^6.3.0",
     "lint-staged": "^9.2.1",
     "prettier": "^1.18.2",
     "rimraf": "~2.6.2",

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -17,6 +17,7 @@ let local = {
 
 [
   'moduleNameMapper',
+  'reporters',
   'setupFilesAfterEnv',
   'setupFiles',
   'moduleFileExtensions'


### PR DESCRIPTION
Fixes #12.

Since we're still waiting to get access to GitHub actions, we can instead fall back to azure pipelines in the meantime.

#### Changes:

- Add `jest-junit`
- Use `reporters` config from upstream `testutils`
- Add configuration for azure pipelines. See [Run pipelines with Anaconda environments](https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/anaconda?view=azure-devops&tabs=ubuntu-16-04) for reference.

We need to use conda to be able to install `xeus-python`.
Here is what it looks like with the azure pipelines enabled on my fork: https://github.com/jtpio/debugger/pull/2

We still need to enable it for this repo and that should be enough.
Maybe we can also add other platforms (Windows) later on if that makes sense.