### PR TITLE
Require xeus-python 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,16 @@ This extension is under active development and is not yet available.
 ## Prerequisites
 
 - JupyterLab 1.1+
+- xeus-python 0.5+
 
 ## Development
 
 ```bash
 # Create a new conda environment
-conda create -n jupyterlab-debugger -c conda-forge jupyterlab nodejs xeus-python ptvsd
+conda create -n jupyterlab-debugger -c conda-forge jupyterlab nodejs xeus-python=0.5 ptvsd
 
 # Activate the conda environment
 conda activate jupyterlab-debugger
-
-# Create a directory for the kernel debug logs in the folder where JupyterLab is started
-mkdir xpython_debug_logs
 
 # Install dependencies
 jlpm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
 
 - bash: |
     source activate jupyterlab-debugger
-    conda install --yes --quiet -c conda-forge nodejs xeus-python ptvsd python=$PYTHON_VERSION
+    conda install --yes --quiet -c conda-forge nodejs xeus-python=0.5 ptvsd python=$PYTHON_VERSION
     python -m pip install -U --pre jupyterlab
   displayName: Install dependencies
 

--- a/tests/run-test.py
+++ b/tests/run-test.py
@@ -2,13 +2,9 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-from jupyterlab.tests.test_app import run_jest, JestApp
+from jupyterlab.tests.test_app import run_jest
 
 HERE = os.path.realpath(os.path.dirname(__file__))
 
 if __name__ == '__main__':
-    # xeus-python requires the xpython_debug_logs folder
-    jest_app = JestApp.instance()
-    os.mkdir(os.path.join(jest_app.notebook_dir, 'xpython_debug_logs'))
-
     run_jest(HERE)


### PR DESCRIPTION
`xeus-python 0.5` has been released and is available on conda forge.

Updating to this version simplifies the setup and using the debugger (the `xpython_debug_logs` folders are created automatically).
