### PR TITLE
Move codemirror types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/disposable": "^1.2.0",
     "@phosphor/widgets": "^1.8.0",
-    "@types/codemirror": "0.0.76",
     "vscode-debugprotocol": "1.35.0"
   },
   "devDependencies": {
@@ -60,6 +59,7 @@
     "@babel/preset-env": "^7.5.5",
     "@jupyterlab/testutils": "^1.1.0",
     "@types/chai": "^4.1.3",
+    "@types/codemirror": "0.0.76",
     "@types/jest": "^24.0.17",
     "chai": "^4.2.0",
     "husky": "^3.0.2",


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/debugger/pull/36/files#r330992142
