### PR TITLE
Fixed debugger restore

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import { IEditorTracker } from '@jupyterlab/fileeditor';
 
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 
+import { UUID } from '@phosphor/coreutils';
+
 import { Debugger } from './debugger';
 
 import { IDebugger, IDebuggerSidebar } from './tokens';
@@ -215,7 +217,7 @@ const tracker: JupyterFrontEndPlugin<IDebugger> = {
     app.commands.addCommand(command, {
       label: 'Debugger',
       execute: args => {
-        const id = (args.id as string) || '';
+        const id = (args.id as string) || UUID.uuid4();
         if (id) {
           console.log('Debugger ID: ', id);
         }


### PR DESCRIPTION
This fixes the problem described by @jtpio [here](https://github.com/jupyterlab/debugger/pull/36#issuecomment-537105099).

The remaining issue is that executing the debugger command creates a new debugger instance while it should reuse the existing one.