### PR TITLE
Upgraded to xeus-python 0.5.3 and replaced updateCell with dumpCell

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This extension is under active development and is not yet available.
 
 ```bash
 # Create a new conda environment
-conda create -n jupyterlab-debugger -c conda-forge jupyterlab nodejs xeus-python=0.5 ptvsd
+conda create -n jupyterlab-debugger -c conda-forge jupyterlab nodejs xeus-python=0.5.3 ptvsd
 
 # Activate the conda environment
 conda activate jupyterlab-debugger

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
 
 - bash: |
     source activate jupyterlab-debugger
-    conda install --yes --quiet -c conda-forge nodejs xeus-python=0.5 ptvsd python=$PYTHON_VERSION
+    conda install --yes --quiet -c conda-forge nodejs xeus-python=0.5.3 ptvsd python=$PYTHON_VERSION
     python -m pip install -U --pre jupyterlab
   displayName: Install dependencies
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -55,22 +55,20 @@ export namespace IDebugger {
 
   export namespace ISession {
     /**
-     * Arguments for 'updateCell' request.
+     * Arguments for 'dumpCell' request.
      * This is an addition to the Debug Adapter Protocol to support
      * setting breakpoints for cells
      */
-    export interface IUpdateCellArguments {
-      cellId: number;
-      nextId: number;
+    export interface IDumpCellArguments {
       code: string;
     }
 
     /**
-     * Response to 'updateCell' request.
+     * Response to 'dumpCell' request.
      * This is an addition to the Debug Adapter Protocol to support
      * setting breakpoints for cells
      */
-    export interface IUpdateCellResponse extends DebugProtocol.Response {
+    export interface IDumpCellResponse extends DebugProtocol.Response {
       body: {
         sourcePath: string;
       };
@@ -113,7 +111,7 @@ export namespace IDebugger {
       terminate: DebugProtocol.TerminateArguments;
       terminateThreads: DebugProtocol.TerminateThreadsArguments;
       threads: {};
-      updateCell: IUpdateCellArguments;
+      dumpCell: IDumpCellArguments;
       variables: DebugProtocol.VariablesArguments;
     };
 
@@ -154,7 +152,7 @@ export namespace IDebugger {
       terminate: DebugProtocol.TerminateResponse;
       terminateThreads: DebugProtocol.TerminateThreadsResponse;
       threads: DebugProtocol.ThreadsResponse;
-      updateCell: IUpdateCellResponse;
+      dumpCell: IDumpCellResponse;
       variables: DebugProtocol.VariablesResponse;
     };
 

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -71,9 +71,7 @@ describe('DebugSession', () => {
 
     it('should send debug messages to the kernel', async () => {
       const code = 'i=0\ni+=1\ni+=1';
-      const reply = await debugSession.sendRequest('updateCell', {
-        cellId: 0,
-        nextId: 1,
+      const reply = await debugSession.sendRequest('dumpCell', {
         code
       });
       expect(reply.body.sourcePath).to.contain('.py');
@@ -130,9 +128,7 @@ describe('protocol', () => {
       }
     );
 
-    const reply = await debugSession.sendRequest('updateCell', {
-      cellId: 0,
-      nextId: 1,
+    const reply = await debugSession.sendRequest('dumpCell', {
       code
     });
     await debugSession.sendRequest('setBreakpoints', {


### PR DESCRIPTION
This simplifies the handling of breakpoints, no need to pass the current execution count nor the next execution count anymore.