### PR TITLE
Add mention to kernelspy extension to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ export XEUS_LOG=1
 
 jlpm run test
 ```
+
+### Inspecting debug messages
+
+The [kernelspy extension for JupyterLab](https://github.com/vidartf/jupyterlab-kernelspy) can be used to inspect the debug messages sent between the debugger UI and the kernel.
+
+To install it:
+
+```bash
+jupyter labextension install jupyterlab-kernelspy
+```


### PR DESCRIPTION
Adding a short mention to the [kernelspy extension for JupyterLab](https://github.com/vidartf/jupyterlab-kernelspy).

This is quite useful to see the debug messages being sent over the network to and from the kernel.

![kernelspy](https://user-images.githubusercontent.com/591645/66475660-13d07a00-ea94-11e9-9931-88d37926b62c.gif)

cc @KsavinN @JohanMabille