### PR TITLE
Start and stop always visible, enabled/disabled

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -15,8 +15,6 @@ import { BoxPanel } from '@phosphor/widgets';
 
 import { IDebugger } from './tokens';
 
-import { DebugSession } from './session';
-
 import { DebuggerSidebar } from './sidebar';
 
 export class Debugger extends BoxPanel {
@@ -57,7 +55,12 @@ export namespace Debugger {
   export class Model implements IDisposable {
     constructor(options: Debugger.Model.IOptions) {
       this.connector = options.connector || null;
-      this.session = new DebugSession({ client: options.session });
+      // Avoids setting session with invalid client
+      // session should be set only when a notebook or
+      // a console get the focus.
+      // TODO: also checks that the notebook or console
+      // runs a kernel with debugging ability
+      this.session = null;
       this.id = options.id;
       void this._populate();
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -88,9 +88,17 @@ export class DebugSession implements IDebugger.ISession {
   }
 
   /**
+   * Whether the debug session is started
+   */
+  get isStarted(): boolean {
+    return this._isStarted;
+  }
+
+  /**
    * Start a new debug session
    */
   async start(): Promise<void> {
+    this._isStarted = true;
     await this.sendRequest('initialize', {
       clientID: 'jupyterlab',
       clientName: 'JupyterLab',
@@ -111,6 +119,7 @@ export class DebugSession implements IDebugger.ISession {
    * Stop the running debug session.
    */
   async stop(): Promise<void> {
+    this._isStarted = false;
     await this.sendRequest('disconnect', {
       restart: false,
       terminateDebuggee: true
@@ -176,6 +185,7 @@ export class DebugSession implements IDebugger.ISession {
 
   private _disposed = new Signal<this, void>(this);
   private _isDisposed: boolean = false;
+  private _isStarted: boolean = false;
   private _eventMessage = new Signal<DebugSession, IDebugger.ISession.Event>(
     this
   );

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -66,6 +66,11 @@ export namespace IDebugger {
     editors: CodeEditor.IEditor[];
 
     /**
+     * Whether the debug session is started
+     */
+    isStarted: boolean;
+
+    /**
      * Start a new debug session.
      */
     start(): Promise<void>;


### PR DESCRIPTION
- ~set ILayoutRestorer and ICommandPalette arguments as required~
- always displays the start and stop commands of the debugge
- start is enabled when a debugging session is available and the debugger has not started yet, disabled otherwise
- stop is enabled when a debugging session is available and the debugger has started, disabled otherwise.

Remaining issues:
- the '_isStarted' cache variable in the DebuggerSession object should be updated upon event notification
- the current implementation creates a new DebuggerSession each time a notebook gets the focus instead of restoring a previous existing session. This breaks the mechanism for enabling and disabling the start and stop commands. The session should be saved somewhere and restored, but I don't know yet the best way to achieve this.