### PR TITLE
Wait for debug event in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       "jlpm run prettier",
       "git add"
     ],
-    "**/*{.ts,.tsx}": [
+    "src/**/*{.ts,.tsx}": [
       "jlpm run tslint",
       "git add"
     ]

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -77,7 +77,7 @@ describe('DebugSession', () => {
       expect(reply.body.sourcePath).to.contain('.py');
     });
 
-    it.skip('should handle replies with success false', async () => {
+    it('should handle replies with success false', async () => {
       const reply = await debugSession.sendRequest('evaluate', {
         expression: 'a'
       });
@@ -216,7 +216,7 @@ describe('protocol', () => {
   });
 
   describe('#continue', () => {
-    it.skip('should proceed to the next breakpoint', async () => {
+    it('should proceed to the next breakpoint', async () => {
       let events: string[] = [];
       const eventsFuture = new PromiseDelegate<string[]>();
       debugSession.eventMessage.connect((sender, event) => {

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 
 import { ClientSession, IClientSession } from '@jupyterlab/apputils';
 
-import { createClientSession, sleep } from '@jupyterlab/testutils';
+import { createClientSession } from '@jupyterlab/testutils';
 
 import { find } from '@phosphor/algorithm';
 
@@ -118,12 +118,19 @@ describe('protocol', () => {
     debugSession = new DebugSession({ client });
     await debugSession.start();
 
+    const stoppedFuture = new PromiseDelegate<void>();
     debugSession.eventMessage.connect(
       (sender: DebugSession, event: IDebugger.ISession.Event) => {
-        const eventName = event.event;
-        if (eventName === 'thread') {
-          const msg = event as DebugProtocol.ThreadEvent;
-          threadId = msg.body.threadId;
+        switch (event.event) {
+          case 'thread':
+            const msg = event as DebugProtocol.ThreadEvent;
+            threadId = msg.body.threadId;
+            break;
+          case 'stopped':
+            stoppedFuture.resolve();
+            break;
+          default:
+            break;
         }
       }
     );
@@ -141,8 +148,8 @@ describe('protocol', () => {
     // trigger an execute_request
     client.kernel.requestExecute({ code });
 
-    // TODO: handle events instead
-    await sleep(2000);
+    // wait for the first stopped event
+    await stoppedFuture.promise;
   });
 
   afterEach(async () => {


### PR DESCRIPTION
### Changes

- Wait for the `stopped` debug event in the tests (instead of waiting for 2s)
- `tslint` check only for source files (for now, might reconsider that later)
- Re-add skipped tests