### PR TITLE
Add editors to the main area widget

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -15,7 +15,7 @@ import { ISignal, Signal } from '@phosphor/signaling';
 
 import { BoxPanel } from '@phosphor/widgets';
 
-import { CodeEditors } from './editors';
+import { DebuggerEditors } from './editors';
 
 import { DebuggerSidebar } from './sidebar';
 
@@ -33,13 +33,13 @@ export class Debugger extends BoxPanel {
     this.model.sidebar = this.sidebar;
 
     const { editorFactory } = options;
-    this.editors = new CodeEditors({ editorFactory });
+    this.editors = new DebuggerEditors({ editorFactory });
     this.addWidget(this.editors);
 
     this.addClass('jp-Debugger');
   }
 
-  readonly editors: CodeEditors;
+  readonly editors: DebuggerEditors;
   readonly model: Debugger.Model;
   readonly sidebar: DebuggerSidebar;
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -25,6 +25,7 @@ export class Debugger extends BoxPanel {
   constructor(options: Debugger.IOptions) {
     super({ direction: 'left-to-right' });
     this.title.label = 'Debugger';
+    this.title.iconClass = 'jp-BugIcon';
 
     this.model = new Debugger.Model(options);
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { CodeEditor } from '@jupyterlab/codeeditor';
+
 import { IDataConnector } from '@jupyterlab/coreutils';
 
 import { ReadonlyJSONValue } from '@phosphor/coreutils';
@@ -11,11 +13,13 @@ import { IDisposable } from '@phosphor/disposable';
 
 import { ISignal, Signal } from '@phosphor/signaling';
 
-import { BoxPanel, TabPanel } from '@phosphor/widgets';
+import { BoxPanel } from '@phosphor/widgets';
 
-import { IDebugger } from './tokens';
+import { CodeEditors } from './editors';
 
 import { DebuggerSidebar } from './sidebar';
+
+import { IDebugger } from './tokens';
 
 export class Debugger extends BoxPanel {
   constructor(options: Debugger.IOptions) {
@@ -27,12 +31,14 @@ export class Debugger extends BoxPanel {
     this.sidebar = new DebuggerSidebar(this.model);
     this.model.sidebar = this.sidebar;
 
-    this.editors = new TabPanel();
+    const { editorFactory } = options;
+    this.editors = new CodeEditors({ editorFactory });
+    this.addWidget(this.editors);
 
     this.addClass('jp-Debugger');
   }
 
-  readonly editors: TabPanel;
+  readonly editors: CodeEditors;
   readonly model: Debugger.Model;
   readonly sidebar: DebuggerSidebar;
 
@@ -50,6 +56,7 @@ export class Debugger extends BoxPanel {
  */
 export namespace Debugger {
   export interface IOptions {
+    editorFactory: CodeEditor.Factory;
     connector?: IDataConnector<ReadonlyJSONValue>;
     id?: string;
     session?: IClientSession;

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -11,7 +11,7 @@ import { IDisposable } from '@phosphor/disposable';
 
 import { ISignal, Signal } from '@phosphor/signaling';
 
-import { BoxPanel } from '@phosphor/widgets';
+import { BoxPanel, TabPanel } from '@phosphor/widgets';
 
 import { IDebugger } from './tokens';
 
@@ -20,16 +20,19 @@ import { DebuggerSidebar } from './sidebar';
 export class Debugger extends BoxPanel {
   constructor(options: Debugger.IOptions) {
     super({ direction: 'left-to-right' });
+    this.title.label = 'Debugger';
+
     this.model = new Debugger.Model(options);
 
     this.sidebar = new DebuggerSidebar(this.model);
-
-    this.title.label = 'Debugger';
     this.model.sidebar = this.sidebar;
+
+    this.editors = new TabPanel();
 
     this.addClass('jp-Debugger');
   }
 
+  readonly editors: TabPanel;
   readonly model: Debugger.Model;
   readonly sidebar: DebuggerSidebar;
 

--- a/src/editors/index.ts
+++ b/src/editors/index.ts
@@ -1,0 +1,79 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+import { CodeEditorWrapper, CodeEditor } from '@jupyterlab/codeeditor';
+
+import { TabPanel } from '@phosphor/widgets';
+
+export class CodeEditors extends TabPanel {
+  constructor(options: CodeEditors.IOptions) {
+    super();
+
+    this.tabsMovable = true;
+
+    this.model = new CodeEditors.IModel(MOCK_EDITORS);
+    this.model.editors.forEach(data => {
+      let editor = new CodeEditorWrapper({
+        model: new CodeEditor.Model(),
+        factory: options.editorFactory,
+        config: { lineNumbers: true }
+      });
+      editor.editor.model.value.text = data.code;
+      editor.editor.model.mimeType = data.mimeType;
+      editor.title.label = data.title;
+      editor.editor.setOption('readOnly', true);
+      editor.title.closable = true;
+
+      this.addWidget(editor);
+    });
+
+    this.addClass('jp-DebuggerEditors');
+  }
+
+  readonly model: CodeEditors.IModel;
+}
+
+export namespace CodeEditors {
+  export interface IOptions {
+    editorFactory?: CodeEditor.Factory;
+  }
+
+  export interface IEditor {
+    title: string;
+    code: string;
+    mimeType: string;
+  }
+
+  export interface IModel {}
+
+  export class IModel implements IModel {
+    constructor(model: CodeEditors.IEditor[]) {
+      this._state = model;
+    }
+
+    addFile(title: string, mimeType: string, code: string) {
+      this._state.push({ title, mimeType, code });
+    }
+
+    get editors() {
+      return this._state;
+    }
+
+    private _state: CodeEditors.IEditor[];
+  }
+}
+
+const MOCK_EDITORS = [
+  {
+    title: 'untitled.py',
+    mimeType: 'text/x-ipython',
+    code: 'import math\nprint(math.pi)'
+  },
+  {
+    title: 'test.py',
+    mimeType: 'text/x-ipython',
+    code: 'import sys\nprint(sys.version)'
+  }
+];

--- a/src/editors/index.ts
+++ b/src/editors/index.ts
@@ -9,13 +9,13 @@ import { ISignal, Signal } from '@phosphor/signaling';
 
 import { TabPanel } from '@phosphor/widgets';
 
-export class CodeEditors extends TabPanel {
-  constructor(options: CodeEditors.IOptions) {
+export class DebuggerEditors extends TabPanel {
+  constructor(options: DebuggerEditors.IOptions) {
     super();
 
     this.tabsMovable = true;
 
-    this.model = new CodeEditors.IModel();
+    this.model = new DebuggerEditors.IModel();
     this.model.editorAdded.connect((sender, data) => {
       let editor = new CodeEditorWrapper({
         model: new CodeEditor.Model({
@@ -40,21 +40,36 @@ export class CodeEditors extends TabPanel {
     this.addClass('jp-DebuggerEditors');
   }
 
+  /**
+   * The debugger editors model.
+   */
+  model: DebuggerEditors.IModel;
+
+  /**
+   * Dispose the debug editors.
+   */
   dispose(): void {
     if (this.isDisposed) {
       return;
     }
     Signal.clearData(this);
   }
-
-  readonly model: CodeEditors.IModel;
 }
 
-export namespace CodeEditors {
+/**
+ * A namespace for `DebuggerEditors` statics.
+ */
+export namespace DebuggerEditors {
+  /**
+   * The options used to create a DebuggerEditors.
+   */
   export interface IOptions {
     editorFactory: CodeEditor.Factory;
   }
 
+  /**
+   * An interface for read only editors.
+   */
   export interface IEditor {
     title: string;
     code: string;
@@ -64,21 +79,34 @@ export namespace CodeEditors {
   export interface IModel {}
 
   export class IModel implements IModel {
-    get editorAdded(): ISignal<CodeEditors.IModel, CodeEditors.IEditor> {
+    /**
+     * A signal emitted when a new editor is added.
+     */
+    get editorAdded(): ISignal<
+      DebuggerEditors.IModel,
+      DebuggerEditors.IEditor
+    > {
       return this._editorAdded;
     }
 
+    /**
+     * Get all the editors currently opened.
+     */
     get editors() {
       return this._state;
     }
 
-    addEditor(editor: CodeEditors.IEditor) {
+    /**
+     * Add a new editor to the editor TabPanel.
+     * @param editor The read-only editor info to add.
+     */
+    addEditor(editor: DebuggerEditors.IEditor) {
       this._state.push(editor);
       this._editorAdded.emit(editor);
     }
 
-    private _state: CodeEditors.IEditor[] = [];
-    private _editorAdded = new Signal<this, CodeEditors.IEditor>(this);
+    private _state: DebuggerEditors.IEditor[] = [];
+    private _editorAdded = new Signal<this, DebuggerEditors.IEditor>(this);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { DebuggerNotebookHandler } from './handlers/notebook';
 import { DebuggerConsoleHandler } from './handlers/console';
 
 import { Kernel } from '@jupyterlab/services';
+import { IEditorServices } from '@jupyterlab/codeeditor';
 
 /**
  * The command IDs used by the debugger plugin.
@@ -208,19 +209,23 @@ const notebooks: JupyterFrontEndPlugin<void> = {
 const main: JupyterFrontEndPlugin<IDebugger> = {
   id: '@jupyterlab/debugger:main',
   optional: [ILayoutRestorer, ICommandPalette],
-  requires: [IStateDB],
+  requires: [IStateDB, IEditorServices],
   provides: IDebugger,
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     state: IStateDB,
+    editorServices: IEditorServices,
     restorer: ILayoutRestorer | null,
     palette: ICommandPalette | null
   ): IDebugger => {
     const tracker = new WidgetTracker<MainAreaWidget<Debugger>>({
       namespace: 'debugger'
     });
+
     const { commands, shell } = app;
+    const editorFactory = editorServices.factoryService.newInlineEditor;
+
     let widget: MainAreaWidget<Debugger>;
 
     const getModel = () => {
@@ -335,7 +340,8 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
           widget = new MainAreaWidget({
             content: new Debugger({
               connector: state,
-              id: id
+              editorFactory,
+              id
             })
           });
 

--- a/style/editors.css
+++ b/style/editors.css
@@ -14,13 +14,14 @@
   min-width: 0;
   min-height: 0;
   align-items: flex-end;
-  border-bottom: 1px solid #c0c0c0;
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
 .jp-DebuggerEditors .p-TabBar-tab {
+  background: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
   padding: 0px 10px;
-  background: #e5e5e5;
-  border: 1px solid #c0c0c0;
+  border: var(--jp-border-width) solid var(--jp-border-color1);
   border-bottom: none;
   font: 12px Helvetica, Arial, sans-serif;
   flex: 0 1 125px;
@@ -38,11 +39,12 @@
 .jp-DebuggerEditors .p-TabBar-tab.p-mod-current {
   min-height: 24px;
   max-height: 24px;
-  background: white;
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
 }
 
 .jp-DebuggerEditors .p-TabBar-tab:hover:not(.p-mod-current) {
-  background: #f0f0f0;
+  background: var(--jp-layout-color1);
 }
 
 .jp-DebuggerEditors .p-TabBar-tabIcon,

--- a/style/editors.css
+++ b/style/editors.css
@@ -1,0 +1,70 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* Values inspired by http://phosphorjs.github.io/examples/tabs/ */
+
+.jp-DebuggerEditors .p-TabBar {
+  min-height: 24px;
+  max-height: 24px;
+}
+
+.jp-DebuggerEditors .p-TabBar-content {
+  min-width: 0;
+  min-height: 0;
+  align-items: flex-end;
+  border-bottom: 1px solid #c0c0c0;
+}
+
+.jp-DebuggerEditors .p-TabBar-tab {
+  padding: 0px 10px;
+  background: #e5e5e5;
+  border: 1px solid #c0c0c0;
+  border-bottom: none;
+  font: 12px Helvetica, Arial, sans-serif;
+  flex: 0 1 125px;
+  min-height: 24px;
+  max-height: 24px;
+  min-width: 35px;
+  margin-left: -1px;
+  line-height: 24px;
+}
+
+.jp-DebuggerEditors .p-TabBar-tab:first-child {
+  margin-left: 0;
+}
+
+.jp-DebuggerEditors .p-TabBar-tab.p-mod-current {
+  min-height: 24px;
+  max-height: 24px;
+  background: white;
+}
+
+.jp-DebuggerEditors .p-TabBar-tab:hover:not(.p-mod-current) {
+  background: #f0f0f0;
+}
+
+.jp-DebuggerEditors .p-TabBar-tabIcon,
+.jp-DebuggerEditors .p-TabBar-tabText,
+.jp-DebuggerEditors .p-TabBar-tabCloseIcon {
+  line-height: 24px;
+}
+
+.jp-DebuggerEditors .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
+  margin-left: 4px;
+  padding-top: 8px;
+  background-size: 16px;
+  height: 16px;
+  width: 16px;
+  background-image: var(--jp-icon-close);
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.jp-DebuggerEditors
+  .p-TabBar-tab.p-mod-closable
+  > .p-TabBar-tabCloseIcon:hover {
+  background-size: 16px;
+  background-image: var(--jp-icon-close-circle);
+}

--- a/style/index.css
+++ b/style/index.css
@@ -8,6 +8,7 @@
 
 @import './icons.css';
 @import './sidebar.css';
+@import './editors.css';
 
 .jp-Debugger {
   background: var(--jp-layout-color1);
@@ -15,7 +16,7 @@
   bottom: 0;
 }
 
-/* font awsome */
+/* font awesome */
 
 .fa {
   display: inline-block;

--- a/tests/src/debugger.spec.ts
+++ b/tests/src/debugger.spec.ts
@@ -1,14 +1,19 @@
 import { expect } from 'chai';
 
+import { CodeMirrorEditorFactory } from '@jupyterlab/codemirror';
+
 import { Debugger } from '../../lib/debugger';
 
 class TestPanel extends Debugger {}
 
 describe('Debugger', () => {
+  const editorServices = new CodeMirrorEditorFactory();
+  const editorFactory = editorServices.newInlineEditor;
+
   let panel: TestPanel;
 
   beforeEach(() => {
-    panel = new TestPanel({});
+    panel = new TestPanel({ editorFactory });
   });
 
   afterEach(() => {


### PR DESCRIPTION
Fixes #56.

The typical usage would involve calling the `addEditor` method when receiving a message from kernel that we hit a breakpoint in a specific file. `addEditor` will show the content of the file that we stepping into (or a previous cell that was executed and then deleted).

This PR does not cover adding breakpoints to the read-only editors (can be done separately).