### PR TITLE
Fix search input for dark theme

### DIFF
--- a/style/variables.css
+++ b/style/variables.css
@@ -99,6 +99,8 @@
 }
 
 .jp-DebuggerVariables-search input {
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
   min-height: 22px;
   vertical-align: top;
   width: 100%;


### PR DESCRIPTION
Just a quick style fix for the dark theme.

### Before

![image](https://user-images.githubusercontent.com/591645/67038050-f730e380-f11e-11e9-85d1-88a80b695f87.png)

### After

![image](https://user-images.githubusercontent.com/591645/67037923-bf29a080-f11e-11e9-9688-efb9062333b8.png)
