### PR TITLE
Add tslint config for sorted imports

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -109,6 +109,13 @@
       "check-operator",
       "check-separator",
       "check-type"
+    ],
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "lowercase-last",
+        "named-imports-order": "lowercase-first"
+      }
     ]
   },
   "linterOptions": {


### PR DESCRIPTION
Fixes #31 

This should automatically sort imports on git commits for the files that have been changed.

We can also consider formatting all the existing files in one PR by running `jlpm run tslint` once.