### PR TITLE
Wait for the session to be ready before restoring state

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -116,7 +116,7 @@ export class DebugSession implements IDebugger.ISession {
 
       await this.sendRequest('attach', {});
     } catch (err) {
-      console.error('Error: ', err.message);
+      console.error('Error:', err.message);
     }
   }
 
@@ -131,7 +131,7 @@ export class DebugSession implements IDebugger.ISession {
       });
       this._isStarted = false;
     } catch (err) {
-      console.error('Error: ', err.message);
+      console.error('Error:', err.message);
     }
   }
 
@@ -139,6 +139,7 @@ export class DebugSession implements IDebugger.ISession {
    * Restore the state of a debug session.
    */
   async restoreState(): Promise<void> {
+    await this.client.ready;
     try {
       const message = await this.sendRequest('debugInfo', {});
       this._isStarted = message.body.isStarted;
@@ -194,8 +195,13 @@ export class DebugSession implements IDebugger.ISession {
   private async _sendDebugMessage(
     msg: KernelMessage.IDebugRequestMsg['content']
   ): Promise<KernelMessage.IDebugReplyMsg> {
-    const reply = new PromiseDelegate<KernelMessage.IDebugReplyMsg>();
     const kernel = this.client.kernel;
+    if (!kernel) {
+      return Promise.reject(
+        new Error('A kernel is required to send debug messages.')
+      );
+    }
+    const reply = new PromiseDelegate<KernelMessage.IDebugReplyMsg>();
     const future = kernel.requestDebug(msg);
     future.onReply = (msg: KernelMessage.IDebugReplyMsg) => {
       return reply.resolve(msg);


### PR DESCRIPTION
Fixes part of #76:

- wait for the session to be ready before restoring the state
- throw an error is the kernel is not available when sending messages

This could be improved later, for example by automatically restoring the debug state when the kernel is restarted.