### PR TITLE
Remove cyclic reference sidebar <-> model

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -37,7 +37,7 @@ export class Debugger extends SplitPanel {
 
     this.model = new Debugger.Model(options);
 
-    this.sidebar = new DebuggerSidebar(this.model);
+    this.sidebar = new DebuggerSidebar();
     this.model.sidebar = this.sidebar;
 
     const { editorFactory } = options;

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -5,16 +5,13 @@ import { SplitPanel } from '@phosphor/widgets';
 
 import { Breakpoints } from './breakpoints';
 
-import { Debugger } from './debugger';
-
 import { Callstack } from './callstack';
 
 import { Variables } from './variables';
 
 export class DebuggerSidebar extends SplitPanel {
-  constructor(model: Debugger.Model | null) {
+  constructor() {
     super();
-    this.model = model;
     this.orientation = 'vertical';
     this.addClass('jp-DebuggerSidebar');
 
@@ -28,21 +25,6 @@ export class DebuggerSidebar extends SplitPanel {
   }
 
   readonly variables: Variables;
-
   readonly callstack: Callstack;
-
   readonly breakpoints: Breakpoints;
-
-  get model(): Debugger.Model | null {
-    return this._model;
-  }
-  set model(model: Debugger.Model | null) {
-    if (this._model === model) {
-      return;
-    }
-    this._model = model;
-    this.update();
-  }
-
-  private _model: Debugger.Model | null = null;
 }


### PR DESCRIPTION
The debugger model is passed to the sidebar but not used.