### PR TITLE
Keep line numbers on when switching cells

### DIFF
--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -119,7 +119,6 @@ export class CellManager implements IDisposable {
     ) {
       if (this.previousCell && !this.previousCell.isDisposed) {
         this.removeListener(this.previousCell);
-        this.clearGutter(this.previousCell);
         this.breakpointsModel.breakpoints = [];
       }
       this.previousCell = this.activeCell;

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -135,6 +135,15 @@ export class CellManager implements IDisposable {
 
     this.previousLineCount = editor.lineCount;
 
+    const editorBreakpoints = this.getBreakpointsInfo(cell);
+    editorBreakpoints.forEach(info => {
+      this.breakpointsModel.addBreakpoint(
+        this._debuggerService.session.client.name,
+        this.getEditorId(),
+        info
+      );
+    });
+
     editor.setOption('lineNumbers', true);
     editor.editor.setOption('gutters', [
       'CodeMirror-linenumbers',
@@ -168,7 +177,7 @@ export class CellManager implements IDisposable {
       this.breakpointsModel.addBreakpoint(
         this._debuggerService.session.client.name,
         this.getEditorId(),
-        info as ILineInfo
+        info
       );
     }
 
@@ -197,6 +206,18 @@ export class CellManager implements IDisposable {
       this.previousLineCount = linesNumber;
     }
   };
+
+  private getBreakpointsInfo(cell: CodeCell): ILineInfo[] {
+    const editor = cell.editor as CodeMirrorEditor;
+    let lines = [];
+    for (let i = 0; i < editor.doc.lineCount(); i++) {
+      const info = editor.editor.lineInfo(i);
+      if (info.gutterMarkers) {
+        lines.push(info);
+      }
+    }
+    return lines;
+  }
 
   private _previousCell: CodeCell;
   private previousLineCount: number;

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -5,13 +5,13 @@ import { CodeCell } from '@jupyterlab/cells';
 
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
-import { Editor, Doc } from 'codemirror';
+import { Doc, Editor } from 'codemirror';
 
 import { Breakpoints, SessionTypes } from '../breakpoints';
 
+import { IDisposable } from '@phosphor/disposable';
 import { Debugger } from '../debugger';
 import { IDebugger } from '../tokens';
-import { IDisposable } from '@phosphor/disposable';
 
 import { Signal } from '@phosphor/signaling';
 
@@ -148,7 +148,6 @@ export class CellManager implements IDisposable {
 
   protected removeListener(cell: CodeCell) {
     const editor = cell.editor as CodeMirrorEditor;
-    editor.setOption('lineNumbers', false);
     editor.editor.off('gutterClick', this.onGutterClick);
     editor.editor.off('renderLine', this.onNewRenderLine);
   }

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -176,7 +176,7 @@ export class CellManager implements IDisposable {
     editor.setGutterMarker(
       lineNumber,
       'breakpoints',
-      isRemoveGutter ? null : this.createMarkerNode()
+      isRemoveGutter ? null : Private.createMarkerNode()
     );
   };
 
@@ -198,13 +198,6 @@ export class CellManager implements IDisposable {
       this.previousLineCount = linesNumber;
     }
   };
-
-  private createMarkerNode() {
-    let marker = document.createElement('div');
-    marker.className = 'jp-breakpoint-marker';
-    marker.innerHTML = '●';
-    return marker;
-  }
 
   private _previousCell: CodeCell;
   private previousLineCount: number;
@@ -236,4 +229,13 @@ export interface ILineInfo {
   wrapClass: string;
   /** Array of line widgets attached to this line. */
   widgets: any;
+}
+
+namespace Private {
+  export function createMarkerNode() {
+    let marker = document.createElement('div');
+    marker.className = 'jp-breakpoint-marker';
+    marker.innerHTML = '●';
+    return marker;
+  }
 }

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -50,7 +50,7 @@ export class DebuggerNotebookHandler implements IDisposable {
     Signal.clearData(this);
   }
 
-  protected onNewCell(noteTracker: NotebookTracker, codeCell: CodeCell) {
+  protected onNewCell(notebookTracker: NotebookTracker, codeCell: CodeCell) {
     if (this.cellManager) {
       this.cellManager.activeCell = codeCell;
     } else {


### PR DESCRIPTION
Fixes #106.

### TODO

- [x] Keep line numbers on when switching cells and the debugger sidebar is available
- [x] Do not clear breakpoints when switching cells
- [x] Retrieve existing breakpoints from the cell editor

edit: adding a screencast

![multiple-cell-breakpoints](https://user-images.githubusercontent.com/591645/67765584-c9b43600-fa4c-11e9-8faf-47ee4c3ae437.gif)