### PR TITLE
Format all imports at once

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import React, { useEffect, useState } from 'react';
-import { Breakpoints } from '.';
 import { ReactWidget } from '@jupyterlab/apputils';
 import { ArrayExt } from '@phosphor/algorithm';
 import { ISignal } from '@phosphor/signaling';
+import React, { useEffect, useState } from 'react';
+import { Breakpoints } from '.';
 
 export class Body extends ReactWidget {
   constructor(model: Breakpoints.Model) {

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -3,11 +3,11 @@
 
 import { Toolbar, ToolbarButton } from '@jupyterlab/apputils';
 
-import { Widget, Panel, PanelLayout } from '@phosphor/widgets';
-import { DebugProtocol } from 'vscode-debugprotocol';
-import { Body } from './body';
 import { Signal } from '@phosphor/signaling';
+import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
+import { DebugProtocol } from 'vscode-debugprotocol';
 import { ILineInfo } from '../handlers/cell';
+import { Body } from './body';
 
 export class Breakpoints extends Panel {
   constructor(options: Breakpoints.IOptions) {

--- a/src/callstack/body.tsx
+++ b/src/callstack/body.tsx
@@ -3,11 +3,11 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { Callstack } from '.';
-
 import { ReactWidget } from '@jupyterlab/apputils';
 
 import { ArrayExt } from '@phosphor/algorithm';
+
+import { Callstack } from '.';
 
 export class Body extends ReactWidget {
   constructor(model: Callstack.Model) {

--- a/src/callstack/index.ts
+++ b/src/callstack/index.ts
@@ -3,10 +3,10 @@
 
 import { Toolbar, ToolbarButton } from '@jupyterlab/apputils';
 
-import { Widget, Panel, PanelLayout } from '@phosphor/widgets';
-import { Body } from './body';
+import { ISignal, Signal } from '@phosphor/signaling';
+import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { Signal, ISignal } from '@phosphor/signaling';
+import { Body } from './body';
 
 export class Callstack extends Panel {
   constructor(options: Callstack.IOptions) {

--- a/src/editors/index.ts
+++ b/src/editors/index.ts
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import { CodeEditorWrapper, CodeEditor } from '@jupyterlab/codeeditor';
+import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
 import { ISignal, Signal } from '@phosphor/signaling';
 

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -5,13 +5,13 @@ import { CodeCell } from '@jupyterlab/cells';
 
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
-import { Editor, Doc } from 'codemirror';
+import { Doc, Editor } from 'codemirror';
 
 import { Breakpoints, SessionTypes } from '../breakpoints';
 
+import { IDisposable } from '@phosphor/disposable';
 import { Debugger } from '../debugger';
 import { IDebugger } from '../tokens';
-import { IDisposable } from '@phosphor/disposable';
 
 import { Signal } from '@phosphor/signaling';
 

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -5,15 +5,17 @@ import { CodeCell } from '@jupyterlab/cells';
 
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
-import { Doc, Editor } from 'codemirror';
+import { IDisposable } from '@phosphor/disposable';
+
+import { Signal } from '@phosphor/signaling';
 
 import { Breakpoints, SessionTypes } from '../breakpoints';
 
-import { IDisposable } from '@phosphor/disposable';
-import { Debugger } from '../debugger';
-import { IDebugger } from '../tokens';
+import { Doc, Editor } from 'codemirror';
 
-import { Signal } from '@phosphor/signaling';
+import { Debugger } from '../debugger';
+
+import { IDebugger } from '../tokens';
 
 const LINE_HIGHLIGHT_CLASS = 'jp-breakpoint-line-highlight';
 

--- a/src/handlers/console.ts
+++ b/src/handlers/console.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IConsoleTracker, CodeConsole } from '@jupyterlab/console';
+import { CodeConsole, IConsoleTracker } from '@jupyterlab/console';
 
 import { CellManager } from '../handlers/cell';
 
@@ -11,9 +11,9 @@ import { Breakpoints } from '../breakpoints';
 
 import { IDebugger } from '../tokens';
 
-import { Debugger } from '../debugger';
 import { IDisposable } from '@phosphor/disposable';
 import { Signal } from '@phosphor/signaling';
+import { Debugger } from '../debugger';
 
 export class DebuggerConsoleHandler implements IDisposable {
   constructor(options: DebuggerConsoleHandler.IOptions) {

--- a/src/handlers/console.ts
+++ b/src/handlers/console.ts
@@ -3,16 +3,18 @@
 
 import { CodeConsole, IConsoleTracker } from '@jupyterlab/console';
 
-import { CellManager } from '../handlers/cell';
-
 import { CodeCell } from '@jupyterlab/cells';
+
+import { IDisposable } from '@phosphor/disposable';
+
+import { Signal } from '@phosphor/signaling';
 
 import { Breakpoints } from '../breakpoints';
 
+import { CellManager } from '../handlers/cell';
+
 import { IDebugger } from '../tokens';
 
-import { IDisposable } from '@phosphor/disposable';
-import { Signal } from '@phosphor/signaling';
 import { Debugger } from '../debugger';
 
 export class DebuggerConsoleHandler implements IDisposable {

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -5,17 +5,17 @@ import { INotebookTracker, NotebookTracker } from '@jupyterlab/notebook';
 
 import { CodeCell } from '@jupyterlab/cells';
 
+import { IDisposable } from '@phosphor/disposable';
+
+import { Signal } from '@phosphor/signaling';
+
+import { Breakpoints } from '../breakpoints';
+
 import { CellManager } from './cell';
 
 import { Debugger } from '../debugger';
 
 import { IDebugger } from '../tokens';
-
-import { Breakpoints } from '../breakpoints';
-
-import { IDisposable } from '@phosphor/disposable';
-
-import { Signal } from '@phosphor/signaling';
 
 export class DebuggerNotebookHandler implements IDisposable {
   constructor(options: DebuggerNotebookHandler.IOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  ILabShell,
   ILayoutRestorer,
   JupyterFrontEnd,
-  JupyterFrontEndPlugin,
-  ILabShell
+  JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
 import {
@@ -17,11 +17,11 @@ import {
 
 import { IEditorServices } from '@jupyterlab/codeeditor';
 
-import { IConsoleTracker, ConsolePanel } from '@jupyterlab/console';
+import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 
 import { IStateDB } from '@jupyterlab/coreutils';
 
-import { IEditorTracker, FileEditor } from '@jupyterlab/fileeditor';
+import { FileEditor, IEditorTracker } from '@jupyterlab/fileeditor';
 
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 

--- a/src/variables/body/index.tsx
+++ b/src/variables/body/index.tsx
@@ -3,12 +3,12 @@
 
 import { Variables } from '../index';
 
-import { ObjectInspector, ObjectLabel, ITheme } from 'react-inspector';
+import { ITheme, ObjectInspector, ObjectLabel } from 'react-inspector';
 
 import { ReactWidget } from '@jupyterlab/apputils';
 
-import React, { useState, useEffect } from 'react';
 import { ArrayExt } from '@phosphor/algorithm';
+import React, { useEffect, useState } from 'react';
 
 export class Body extends ReactWidget {
   constructor(model: Variables.Model) {

--- a/src/variables/body/index.tsx
+++ b/src/variables/body/index.tsx
@@ -1,14 +1,15 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Variables } from '../index';
-
-import { ITheme, ObjectInspector, ObjectLabel } from 'react-inspector';
-
 import { ReactWidget } from '@jupyterlab/apputils';
 
 import { ArrayExt } from '@phosphor/algorithm';
+
 import React, { useEffect, useState } from 'react';
+
+import { ITheme, ObjectInspector, ObjectLabel } from 'react-inspector';
+
+import { Variables } from '../index';
 
 export class Body extends ReactWidget {
   constructor(model: Variables.Model) {

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Panel, Widget, PanelLayout } from '@phosphor/widgets';
+import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 
 import { Body } from './body';
 
-import { Signal, ISignal } from '@phosphor/signaling';
+import { ISignal, Signal } from '@phosphor/signaling';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -3,11 +3,11 @@
 
 import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 
-import { Body } from './body';
-
 import { ISignal, Signal } from '@phosphor/signaling';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
+
+import { Body } from './body';
 
 export class Variables extends Panel {
   constructor(options: Variables.IOptions) {


### PR DESCRIPTION
With the new `ordered-imports` option added in https://github.com/jupyterlab/debugger/pull/72 and the pre-commit hook, we started having the imports sorted automatically on commit.

I would suggest we format them all at once now to minimize conflicts in the near future.

Also it seems that the pre-commit hook will need to be updated to only format the files that have been changed.