### PR TITLE
Automagically starts the debugger if the kernel supports it

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import React, { useEffect, useState } from 'react';
-import { Breakpoints } from '.';
 import { ReactWidget } from '@jupyterlab/apputils';
 import { ArrayExt } from '@phosphor/algorithm';
 import { ISignal } from '@phosphor/signaling';
+import React, { useEffect, useState } from 'react';
+import { Breakpoints } from '.';
 
 export class Body extends ReactWidget {
   constructor(model: Breakpoints.Model) {

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -3,11 +3,11 @@
 
 import { Toolbar, ToolbarButton } from '@jupyterlab/apputils';
 
-import { Widget, Panel, PanelLayout } from '@phosphor/widgets';
-import { DebugProtocol } from 'vscode-debugprotocol';
-import { Body } from './body';
 import { Signal } from '@phosphor/signaling';
+import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
+import { DebugProtocol } from 'vscode-debugprotocol';
 import { ILineInfo } from '../handlers/cell';
+import { Body } from './body';
 
 export class Breakpoints extends Panel {
   constructor(options: Breakpoints.IOptions) {

--- a/src/callstack/index.ts
+++ b/src/callstack/index.ts
@@ -3,10 +3,10 @@
 
 import { Toolbar, ToolbarButton } from '@jupyterlab/apputils';
 
-import { Widget, Panel, PanelLayout } from '@phosphor/widgets';
-import { Body } from './body';
+import { ISignal, Signal } from '@phosphor/signaling';
+import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { Signal, ISignal } from '@phosphor/signaling';
+import { Body } from './body';
 
 export class Callstack extends Panel {
   constructor(options: Callstack.IOptions) {

--- a/src/editors/index.ts
+++ b/src/editors/index.ts
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import { CodeEditorWrapper, CodeEditor } from '@jupyterlab/codeeditor';
+import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
 import { ISignal, Signal } from '@phosphor/signaling';
 

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -5,13 +5,13 @@ import { CodeCell } from '@jupyterlab/cells';
 
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
-import { Editor, Doc } from 'codemirror';
+import { Doc, Editor } from 'codemirror';
 
 import { Breakpoints, SessionTypes } from '../breakpoints';
 
+import { IDisposable } from '@phosphor/disposable';
 import { Debugger } from '../debugger';
 import { IDebugger } from '../tokens';
-import { IDisposable } from '@phosphor/disposable';
 
 import { Signal } from '@phosphor/signaling';
 

--- a/src/handlers/console.ts
+++ b/src/handlers/console.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IConsoleTracker, CodeConsole } from '@jupyterlab/console';
+import { CodeConsole, IConsoleTracker } from '@jupyterlab/console';
 
 import { CellManager } from '../handlers/cell';
 
@@ -11,9 +11,9 @@ import { Breakpoints } from '../breakpoints';
 
 import { IDebugger } from '../tokens';
 
-import { Debugger } from '../debugger';
 import { IDisposable } from '@phosphor/disposable';
 import { Signal } from '@phosphor/signaling';
+import { Debugger } from '../debugger';
 
 export class DebuggerConsoleHandler implements IDisposable {
   constructor(options: DebuggerConsoleHandler.IOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,9 @@ async function setDebugSession(
     debug.session.client = client;
   }
   await debug.session.restoreState();
+  if (debug.canStart()) {
+    await debug.start();
+  }
   app.commands.notifyCommandChanged();
 }
 
@@ -243,7 +246,7 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
     let widget: MainAreaWidget<Debugger>;
 
     commands.addCommand(CommandIDs.mount, {
-      execute: args => {
+      execute: async args => {
         if (!widget) {
           return;
         }
@@ -277,28 +280,10 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
         sidebar.id = 'jp-debugger-sidebar';
         sidebar.title.label = 'Environment';
         shell.add(sidebar, 'right', { activate: false });
-      }
-    });
 
-    commands.addCommand(CommandIDs.stop, {
-      label: 'Stop',
-      isEnabled: () => {
-        return service.isStarted();
-      },
-      execute: async () => {
-        await service.session.stop();
-        commands.notifyCommandChanged();
-      }
-    });
-
-    commands.addCommand(CommandIDs.start, {
-      label: 'Start',
-      isEnabled: () => {
-        return widget && service.canStart();
-      },
-      execute: async () => {
-        await service.session.start();
-        commands.notifyCommandChanged();
+        if (service.canStart()) {
+          await service.start();
+        }
       }
     });
 
@@ -393,8 +378,6 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
       const category = 'Debugger';
       palette.addItem({ command: CommandIDs.changeMode, category });
       palette.addItem({ command: CommandIDs.create, category });
-      palette.addItem({ command: CommandIDs.start, category });
-      palette.addItem({ command: CommandIDs.stop, category });
       palette.addItem({ command: CommandIDs.debugContinue, category });
       palette.addItem({ command: CommandIDs.next, category });
       palette.addItem({ command: CommandIDs.stepIn, category });

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -58,6 +58,18 @@ export interface IDebugger {
   isThreadStopped(): boolean;
 
   /**
+   * Starts a debugger.
+   * Precondition: canStart() && !isStarted()
+   */
+  start(): Promise<void>;
+
+  /**
+   * Stops the debugger.
+   * Precondition: isStarted()
+   */
+  stop(): Promise<void>;
+
+  /**
    * Continues the execution of the current thread.
    */
   continue(): Promise<void>;

--- a/src/variables/body/index.tsx
+++ b/src/variables/body/index.tsx
@@ -3,12 +3,12 @@
 
 import { Variables } from '../index';
 
-import { ObjectInspector, ObjectLabel, ITheme } from 'react-inspector';
+import { ITheme, ObjectInspector, ObjectLabel } from 'react-inspector';
 
 import { ReactWidget } from '@jupyterlab/apputils';
 
-import React, { useState, useEffect } from 'react';
 import { ArrayExt } from '@phosphor/algorithm';
+import React, { useEffect, useState } from 'react';
 
 export class Body extends ReactWidget {
   constructor(model: Variables.Model) {

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Panel, Widget, PanelLayout } from '@phosphor/widgets';
+import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 
 import { Body } from './body';
 
-import { Signal, ISignal } from '@phosphor/signaling';
+import { ISignal, Signal } from '@phosphor/signaling';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 


### PR DESCRIPTION
Fixes #117 and #110.

This removes the start and stop commands form the palette and implements the following behavior:
- when clicking on "Debugger" in the palette, the kernel of the notebook or console that has the focus starts a debugger if it can
- when opening a notebook or a console while the Debugger panel is already mounted, he associated kernel starts a debugger it it can.
- a running debugger is never manually stoppable (it will be stopped when the kernel dies).