### PR TITLE
Set editors breakpoints on model changed

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -44,13 +44,17 @@ const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
 
   return (
     <div>
-      {breakpoints.map((breakpoint: Breakpoints.IBreakpoint) => (
-        <BreakpointComponent
-          key={breakpoint.line}
-          breakpoint={breakpoint}
-          breakpointChanged={model.breakpointChanged}
-        />
-      ))}
+      {breakpoints
+        .sort((a, b) => {
+          return a.line - b.line;
+        })
+        .map((breakpoint: Breakpoints.IBreakpoint) => (
+          <BreakpointComponent
+            key={breakpoint.line}
+            breakpoint={breakpoint}
+            breakpointChanged={model.breakpointChanged}
+          />
+        ))}
     </div>
   );
 };

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -6,7 +6,6 @@ import { Toolbar, ToolbarButton } from '@jupyterlab/apputils';
 import { Signal } from '@phosphor/signaling';
 import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { ILineInfo } from '../handlers/cell';
 import { Body } from './body';
 
 export class Breakpoints extends Panel {
@@ -108,15 +107,7 @@ export namespace Breakpoints {
       }
     }
 
-    addBreakpoint(session: string, type: string, lineInfo: ILineInfo) {
-      const breakpoint: Breakpoints.IBreakpoint = {
-        line: lineInfo.line + 1,
-        active: true,
-        verified: true,
-        source: {
-          name: session
-        }
-      };
+    addBreakpoint(breakpoint: IBreakpoint) {
       this.breakpoints = [...this._breakpoints, breakpoint];
     }
 
@@ -129,10 +120,8 @@ export namespace Breakpoints {
       this.breakpoints = this._state[newType];
     }
 
-    removeBreakpoint(lineInfo: any) {
-      const breakpoints = this.breakpoints.filter(
-        ele => ele.line !== lineInfo.line + 1
-      );
+    removeBreakpoint(line: number) {
+      const breakpoints = this.breakpoints.filter(ele => ele.line !== line);
       this.breakpoints = breakpoints;
     }
 
@@ -141,17 +130,17 @@ export namespace Breakpoints {
       this.clearedBreakpoints.emit(this._selectedType);
     }
 
-    changeLines(linesInfo: ILineInfo[]) {
-      if (!linesInfo && this.breakpoints.length === 0) {
+    changeLines(lines: number[]) {
+      if (!lines && this.breakpoints.length === 0) {
         return;
       }
-      if (linesInfo.length === 0) {
+      if (lines.length === 0) {
         this.breakpoints = [];
       } else {
         const breakpoint = { ...this.breakpoints[0] };
         let breakpoints: Breakpoints.IBreakpoint[] = [];
-        linesInfo.forEach(ele => {
-          breakpoints.push({ ...breakpoint, line: ele.line + 1 });
+        lines.forEach(line => {
+          breakpoints.push({ ...breakpoint, line });
         });
         this.breakpoints = [...breakpoints];
       }

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -120,7 +120,7 @@ export namespace Breakpoints {
       this.breakpoints = this._state[newType];
     }
 
-    removeBreakpoint(line: number) {
+    removeBreakpointAtLine(line: number) {
       const breakpoints = this.breakpoints.filter(ele => ele.line !== line);
       this.breakpoints = breakpoints;
     }

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -41,7 +41,7 @@ export class Breakpoints extends Panel {
       new ToolbarButton({
         iconClassName: 'jp-CloseAllIcon',
         onClick: () => {
-          this.model.clearSelectedBreakpoints();
+          this.model.clearAllBreakpoints();
         },
         tooltip: 'Remove All Breakpoints'
       })
@@ -80,7 +80,6 @@ export namespace Breakpoints {
     }
 
     breakpointsChanged = new Signal<this, IBreakpoint[]>(this);
-    clearedBreakpoints = new Signal<this, SessionTypes | null>(this);
 
     get breakpoints(): IBreakpoint[] {
       return this._breakpoints;
@@ -125,9 +124,8 @@ export namespace Breakpoints {
       this.breakpoints = breakpoints;
     }
 
-    clearSelectedBreakpoints() {
+    clearAllBreakpoints() {
       this.breakpoints = [];
-      this.clearedBreakpoints.emit(this._selectedType);
     }
 
     changeLines(lines: number[]) {

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -41,7 +41,7 @@ export class Breakpoints extends Panel {
       new ToolbarButton({
         iconClassName: 'jp-CloseAllIcon',
         onClick: () => {
-          this.model.clearAllBreakpoints();
+          this.model.removeAllBreakpoints();
         },
         tooltip: 'Remove All Breakpoints'
       })
@@ -124,7 +124,7 @@ export namespace Breakpoints {
       this.breakpoints = breakpoints;
     }
 
-    clearAllBreakpoints() {
+    removeAllBreakpoints() {
       this.breakpoints = [];
     }
 

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -23,15 +23,7 @@ export class CellManager implements IDisposable {
     this._debuggerService = options.debuggerService;
     this.breakpointsModel = options.breakpointsModel;
     this.activeCell = options.activeCell;
-    this._type = options.type;
     this.onActiveCellChanged();
-
-    this.breakpointsModel.clearedBreakpoints.connect((_, type) => {
-      if (type !== this._type) {
-        return;
-      }
-      this.clearGutter(this.activeCell);
-    });
 
     this._debuggerModel.currentLineChanged.connect((_, lineNumber) => {
       this.showCurrentLine(lineNumber);
@@ -232,7 +224,6 @@ export class CellManager implements IDisposable {
   private _previousCell: CodeCell;
   private previousLineCount: number;
   private _debuggerModel: Debugger.Model;
-  private _type: SessionTypes;
   private breakpointsModel: Breakpoints.Model;
   private _activeCell: CodeCell;
   private _debuggerService: IDebugger;

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -172,7 +172,7 @@ export class CellManager implements IDisposable {
 
     const isRemoveGutter = !!info.gutterMarkers;
     if (isRemoveGutter) {
-      this.breakpointsModel.removeBreakpoint(info.line + 1);
+      this.breakpointsModel.removeBreakpointAtLine(info.line + 1);
     } else {
       this.breakpointsModel.addBreakpoint(
         Private.createBreakpoint(

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -42,6 +42,7 @@ export class CellManager implements IDisposable {
     });
 
     this.breakpointsModel.breakpointsChanged.connect(async () => {
+      this.addBreakpointsToEditor(this.activeCell);
       await this._debuggerService.updateBreakpoints();
     });
   }
@@ -180,12 +181,6 @@ export class CellManager implements IDisposable {
         info
       );
     }
-
-    editor.setGutterMarker(
-      lineNumber,
-      'breakpoints',
-      isRemoveGutter ? null : Private.createMarkerNode()
-    );
   };
 
   protected onNewRenderLine = (editor: Editor, line: any) => {
@@ -206,6 +201,19 @@ export class CellManager implements IDisposable {
       this.previousLineCount = linesNumber;
     }
   };
+
+  private addBreakpointsToEditor(cell: CodeCell) {
+    this.clearGutter(cell);
+    const editor = cell.editor as CodeMirrorEditor;
+    const breakpoints = this._debuggerModel.breakpointsModel.breakpoints;
+    breakpoints.forEach(breakpoint => {
+      editor.editor.setGutterMarker(
+        breakpoint.line - 1,
+        'breakpoints',
+        Private.createMarkerNode()
+      );
+    });
+  }
 
   private getBreakpointsInfo(cell: CodeCell): ILineInfo[] {
     const editor = cell.editor as CodeMirrorEditor;


### PR DESCRIPTION
Fixes #119 

The idea is to have one central place where breakpoints are added to the editor, that should be triggered when the model changes.

### Summary of the changes

- Keep breakpoints sorted by line number
- Unify the naming of the breakpoints model methods
- Pass line numbers instead of `ILineInfo` to the breakpoint model
- Remove `clearedBreakpoints` signal