### PR TITLE
Use changed signal for models

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -35,10 +35,10 @@ const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
       setBreakpoints(updates);
     };
 
-    model.breakpointsChanged.connect(updateBreakpoints);
+    model.changed.connect(updateBreakpoints);
 
     return () => {
-      model.breakpointsChanged.disconnect(updateBreakpoints);
+      model.changed.disconnect(updateBreakpoints);
     };
   });
 
@@ -98,7 +98,7 @@ const BreakpointComponent = ({
         checked={active}
       />
       <span>
-        {breakpoint.source.path} : {breakpoint.line}
+        {breakpoint.source.name} : {breakpoint.line}
       </span>
     </div>
   );

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -82,7 +82,7 @@ export namespace Breakpoints {
       this._breakpoints = model;
     }
 
-    breakpointsChanged = new Signal<this, IBreakpoint[]>(this);
+    changed = new Signal<this, IBreakpoint[]>(this);
 
     get breakpoints(): IBreakpoint[] {
       return this._breakpoints;
@@ -94,7 +94,7 @@ export namespace Breakpoints {
 
     set breakpoints(breakpoints: IBreakpoint[]) {
       this._breakpoints = [...breakpoints];
-      this.breakpointsChanged.emit(this._breakpoints);
+      this.changed.emit(this._breakpoints);
     }
 
     set breakpoint(breakpoint: IBreakpoint) {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -151,14 +151,6 @@ export namespace Debugger {
       this._codeValue = observableString;
     }
 
-    get currentLineChanged() {
-      return this._currentLineChanged;
-    }
-
-    get linesCleared() {
-      return this._linesCleared;
-    }
-
     dispose(): void {
       this._isDisposed = true;
     }
@@ -175,8 +167,6 @@ export namespace Debugger {
     private _isDisposed = false;
     private _mode: IDebugger.Mode;
     private _modeChanged = new Signal<this, IDebugger.Mode>(this);
-    private _currentLineChanged = new Signal<this, number>(this);
-    private _linesCleared = new Signal<this, void>(this);
   }
 
   export namespace Sidebar {

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -25,15 +25,16 @@ export class CellManager implements IDisposable {
     this.activeCell = options.activeCell;
     this.onActiveCellChanged();
 
-    this._debuggerModel.currentLineChanged.connect((_, lineNumber) => {
-      this.showCurrentLine(lineNumber);
-    });
-
-    this._debuggerModel.linesCleared.connect(() => {
+    this._debuggerModel.variablesModel.changed.connect(() => {
       this.cleanupHighlight();
+      const firstFrame = this._debuggerModel.callstackModel.frames[0];
+      if (!firstFrame) {
+        return;
+      }
+      this.showCurrentLine(firstFrame.line);
     });
 
-    this.breakpointsModel.breakpointsChanged.connect(async () => {
+    this.breakpointsModel.changed.connect(async () => {
       if (!this.activeCell || this.activeCell.isDisposed) {
         return;
       }

--- a/src/service.ts
+++ b/src/service.ts
@@ -158,7 +158,6 @@ export class DebugService implements IDebugger {
       });
       if (index === 0) {
         this._model.variablesModel.scopes = values;
-        this._model.currentLineChanged.emit(frame.line);
       }
     });
 
@@ -275,7 +274,6 @@ export class DebugService implements IDebugger {
   };
 
   private onContinued() {
-    this._model.linesCleared.emit();
     this._model.callstackModel.frames = [];
     this._model.variablesModel.scopes = [];
   }
@@ -290,7 +288,10 @@ export class DebugService implements IDebugger {
   private _sessionChanged = new Signal<IDebugger, IDebugger.ISession>(this);
   private _eventMessage = new Signal<IDebugger, IDebugger.ISession.Event>(this);
   private _model: Debugger.Model;
+
+  // TODO: remove frames from the service
   private frames: Frame[] = [];
+
   // TODO: move this in model
   private _threadStopped = new Set();
 }

--- a/src/variables/body/index.tsx
+++ b/src/variables/body/index.tsx
@@ -28,17 +28,17 @@ const VariableComponent = ({ model }: { model: Variables.Model }) => {
   const [data, setData] = useState(model.scopes);
 
   useEffect(() => {
-    const updateScopes = (_: Variables.Model, update: Variables.IScope[]) => {
-      if (ArrayExt.shallowEqual(data, update)) {
+    const updateScopes = () => {
+      if (ArrayExt.shallowEqual(data, model.scopes)) {
         return;
       }
-      setData(update);
+      setData(model.scopes);
     };
 
-    model.scopesChanged.connect(updateScopes);
+    model.changed.connect(updateScopes);
 
     return () => {
-      model.scopesChanged.disconnect(updateScopes);
+      model.changed.disconnect(updateScopes);
     };
   });
 

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -64,8 +64,8 @@ export namespace Variables {
       this._state = model;
     }
 
-    get scopesChanged(): ISignal<this, IScope[]> {
-      return this._scopesChanged;
+    get changed(): ISignal<this, void> {
+      return this._changed;
     }
 
     get currentVariable(): IVariable {
@@ -77,7 +77,7 @@ export namespace Variables {
         return;
       }
       this._currentVariable = variable;
-      this._currentChanged.emit(variable);
+      this._currentVariableChanged.emit(variable);
     }
 
     get scopes(): IScope[] {
@@ -86,7 +86,7 @@ export namespace Variables {
 
     set scopes(scopes: IScope[]) {
       this._state = scopes;
-      this._scopesChanged.emit(scopes);
+      this._changed.emit();
     }
 
     get variables(): IVariable[] {
@@ -95,10 +95,7 @@ export namespace Variables {
 
     set variables(variables: IVariable[]) {
       this._currentScope.variables = variables;
-    }
-
-    get variablesChanged(): ISignal<this, IVariable[]> {
-      return this._variablesChanged;
+      this._changed.emit();
     }
 
     getCurrentVariables(): IVariable[] {
@@ -110,9 +107,8 @@ export namespace Variables {
     private _currentVariable: IVariable;
     private _currentScope: IScope;
 
-    private _currentChanged = new Signal<this, IVariable>(this);
-    private _variablesChanged = new Signal<this, IVariable[]>(this);
-    private _scopesChanged = new Signal<this, IScope[]>(this);
+    private _changed = new Signal<this, void>(this);
+    private _currentVariableChanged = new Signal<this, IVariable>(this);
   }
 
   export interface IOptions extends Panel.IOptions {


### PR DESCRIPTION
Fixes #134 

All models should have a `changed` signal.

Some models still have additional signals such as `_currentVariableChanged` that have been kept for now (we might or might not need them later on).

This PR is building on top of #132 and should be rebased once #132 is merged into master.

For a cleaner diff of the change, see https://github.com/jtpio/debugger/pull/4