### PR TITLE
Fixed cell manager when debugger panel is closed and reopened

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -56,6 +56,7 @@ export class DebugService implements IDebugger {
 
   set model(model: Debugger.Model) {
     this._model = model;
+    this._modelChanged.emit(model);
   }
 
   get session(): IDebugger.ISession {
@@ -139,6 +140,10 @@ export class DebugService implements IDebugger {
 
   get sessionChanged(): ISignal<IDebugger, IDebugger.ISession> {
     return this._sessionChanged;
+  }
+
+  get modelChanged(): ISignal<IDebugger, Debugger.Model> {
+    return this._modelChanged;
   }
 
   get eventMessage(): ISignal<IDebugger, IDebugger.ISession.Event> {
@@ -286,6 +291,7 @@ export class DebugService implements IDebugger {
   private _isDisposed: boolean = false;
   private _session: IDebugger.ISession;
   private _sessionChanged = new Signal<IDebugger, IDebugger.ISession>(this);
+  private _modelChanged = new Signal<IDebugger, Debugger.Model>(this);
   private _eventMessage = new Signal<IDebugger, IDebugger.ISession.Event>(this);
   private _model: Debugger.Model;
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -96,6 +96,11 @@ export interface IDebugger {
   sessionChanged: ISignal<IDebugger, IDebugger.ISession>;
 
   /**
+   * Signal emitted upon model changed.
+   */
+  modelChanged: ISignal<IDebugger, Debugger.Model>;
+
+  /**
    * Signal emitted for debug event messages.
    */
   eventMessage: ISignal<IDebugger, IDebugger.ISession.Event>;


### PR DESCRIPTION
Currenlty, the debugger model is saved in the cell manager. The problem is that it is not correctly reset when the debugger panel is closed and the model is disposed.

Symetrically, when the debugger panel is opened again, the cell manager should be updated and the active cell should reset the current code value in the model.

Other handlers (notebook and consoles) should be fixed the same way since they keep a reference on the debugger model.