### PR TITLE
Use source path for the breakpoints view

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -98,7 +98,7 @@ const BreakpointComponent = ({
         checked={active}
       />
       <span>
-        {breakpoint.source.name} : {breakpoint.line}
+        {breakpoint.source.path} : {breakpoint.line}
       </span>
     </div>
   );


### PR DESCRIPTION
The name of the source was not displayed anymore.

### Before

![image](https://user-images.githubusercontent.com/591645/68113108-42a30a00-fef3-11e9-9785-edfae114687e.png)

### After

![image](https://user-images.githubusercontent.com/591645/68113074-2ef7a380-fef3-11e9-9ae0-33efafaefa7f.png)
