### PR TITLE
Notebook bp

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,4 +6,4 @@ dependencies:
 - nodejs
 - notebook=6
 - ptvsd
-- xeus-python=0.6
+- xeus-python=0.6.4

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/disposable": "^1.2.0",
     "@phosphor/widgets": "^1.8.0",
+    "murmurhash-js": "^1.0.0",
     "vscode-debugprotocol": "1.35.0",
     "react-inspector": "^2.0.0"
   },
@@ -66,6 +67,7 @@
     "@types/chai": "^4.1.3",
     "@types/codemirror": "0.0.76",
     "@types/jest": "^24.0.17",
+    "@types/murmurhash-js": "1.0.3",
     "chai": "^4.2.0",
     "husky": "^3.0.2",
     "jest": "^24.8.0",

--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -22,30 +22,35 @@ export class Body extends ReactWidget {
 }
 
 const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
-  const [breakpoints, setBreakpoints] = useState(model.breakpoints);
+  const [breakpoints, setBreakpoints] = useState(
+    Array.from(model.breakpoints.entries())
+  );
 
   useEffect(() => {
     const updateBreakpoints = (
       _: Breakpoints.Model,
       updates: Breakpoints.IBreakpoint[]
     ) => {
-      /*if (ArrayExt.shallowEqual(breakpoints, updates)) {
-        return;
-      }*/
-      setBreakpoints(model.breakpoints);
+      setBreakpoints(Array.from(model.breakpoints.entries()));
+    };
+
+    const restoreBreakpoints = (_: Breakpoints.Model) => {
+      setBreakpoints(Array.from(model.breakpoints.entries()));
     };
 
     model.changed.connect(updateBreakpoints);
+    model.restored.connect(restoreBreakpoints);
 
     return () => {
       model.changed.disconnect(updateBreakpoints);
+      model.restored.disconnect(restoreBreakpoints);
     };
   });
 
   return (
     <div>
-      {Array.from(breakpoints.entries()).map(entry => (
-        // breakpoints.forEach((val, key, m) => (
+      {breakpoints.map(entry => (
+        // Array.from(breakpoints.entries()).map((entry) => (
         <BreakpointCellComponent
           key={entry[0]}
           breakpoints={entry[1]}
@@ -54,22 +59,6 @@ const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
       ))}
     </div>
   );
-
-  /*return (
-    <div>
-      {breakpoints
-        .sort((a, b) => {
-          return a.line - b.line;
-        })
-        .map((breakpoint: Breakpoints.IBreakpoint) => (
-          <BreakpointComponent
-            key={breakpoint.line}
-            breakpoint={breakpoint}
-            breakpointChanged={model.breakpointChanged}
-          />
-        ))}
-    </div>
-  );*/
 };
 
 const BreakpointCellComponent = ({
@@ -87,7 +76,7 @@ const BreakpointCellComponent = ({
         })
         .map((breakpoint: Breakpoints.IBreakpoint) => (
           <BreakpointComponent
-            key={breakpoint.line}
+            key={breakpoint.source.path + breakpoint.line}
             breakpoint={breakpoint}
             breakpointChanged={model.breakpointChanged}
           />

--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { ReactWidget } from '@jupyterlab/apputils';
-import { ArrayExt } from '@phosphor/algorithm';
+// import { ArrayExt } from '@phosphor/algorithm';
 import { ISignal } from '@phosphor/signaling';
 import React, { useEffect, useState } from 'react';
 import { Breakpoints } from '.';
@@ -29,10 +29,10 @@ const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
       _: Breakpoints.Model,
       updates: Breakpoints.IBreakpoint[]
     ) => {
-      if (ArrayExt.shallowEqual(breakpoints, updates)) {
+      /*if (ArrayExt.shallowEqual(breakpoints, updates)) {
         return;
-      }
-      setBreakpoints(updates);
+      }*/
+      setBreakpoints(model.breakpoints);
     };
 
     model.changed.connect(updateBreakpoints);
@@ -42,6 +42,43 @@ const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
     };
   });
 
+  return (
+    <div>
+      {Array.from(breakpoints.entries()).map(entry => (
+        // breakpoints.forEach((val, key, m) => (
+        <BreakpointCellComponent
+          key={entry[0]}
+          breakpoints={entry[1]}
+          model={model}
+        />
+      ))}
+    </div>
+  );
+
+  /*return (
+    <div>
+      {breakpoints
+        .sort((a, b) => {
+          return a.line - b.line;
+        })
+        .map((breakpoint: Breakpoints.IBreakpoint) => (
+          <BreakpointComponent
+            key={breakpoint.line}
+            breakpoint={breakpoint}
+            breakpointChanged={model.breakpointChanged}
+          />
+        ))}
+    </div>
+  );*/
+};
+
+const BreakpointCellComponent = ({
+  breakpoints,
+  model
+}: {
+  breakpoints: Breakpoints.IBreakpoint[];
+  model: Breakpoints.Model;
+}) => {
   return (
     <div>
       {breakpoints

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -31,10 +31,13 @@ export class Breakpoints extends Panel {
         tooltip: `${this.isAllActive ? 'Deactivate' : 'Activate'} Breakpoints`,
         onClick: () => {
           this.isAllActive = !this.isAllActive;
-          this.model.breakpoints.map((breakpoint: Breakpoints.IBreakpoint) => {
-            breakpoint.active = this.isAllActive;
-            this.model.breakpoint = breakpoint;
-          });
+          // TODO: this requires a set breakpoint(bp: Breakpoints.IBreakpoint[]) method in the model
+          /*Array.from(this.model.breakpoints.values()).map((breakpoints: Breakpoints.IBreakpoint[]) => {
+            breakpoints.map((breakpoint: Breakpoints.IBreakpoint) => {
+              breakpoint.active = this.isAllActive;
+              this.model.breakpoint = breakpoint;
+            });
+          });*/
         }
       })
     );
@@ -159,7 +162,7 @@ export namespace Breakpoints {
       return this._changed;
     }
 
-    get restored(): Signal<this, string> {
+    get restored(): Signal<this, void> {
       return this._restored;
     }
 
@@ -167,6 +170,7 @@ export namespace Breakpoints {
       return this._breakpoints;
     }
 
+    // kept for react component
     get breakpointChanged(): Signal<this, IBreakpoint> {
       return this._breakpointChanged;
     }
@@ -181,18 +185,26 @@ export namespace Breakpoints {
     }
 
     getBreakpoints(code: string): IBreakpoint[] {
-      return this._breakpoints.get(this.hash(code));
+      return this._breakpoints.get(this.hash(code)) || [];
     }
 
     restoreBreakpoints(breakpoints: Map<string, IBreakpoint[]>) {
       this._breakpoints = breakpoints;
-      this._restored.emit('restored');
+      this._restored.emit();
     }
+
+    /*private printMap() {
+      this._breakpoints.forEach((value, key, map) => {
+        console.log(key);
+        value.forEach((bp) => console.log(bp.line));
+      });
+    }*/
 
     private _hashMethod: (code: string) => string;
     private _breakpoints = new Map<string, IBreakpoint[]>();
     private _changed = new Signal<this, IBreakpoint[]>(this);
-    private _restored = new Signal<this, string>(this);
+    private _restored = new Signal<this, void>(this);
+    // kept for react component
     private _breakpointChanged = new Signal<this, IBreakpoint>(this);
   }
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -111,7 +111,7 @@ export namespace Debugger {
 
   export class Model implements IDisposable {
     constructor(options: Debugger.Model.IOptions) {
-      this.breakpointsModel = new Breakpoints.Model([]);
+      this.breakpointsModel = new Breakpoints.Model();
       this.callstackModel = new Callstack.Model([]);
       this.variablesModel = new Variables.Model([]);
       this.connector = options.connector || null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,10 +78,7 @@ async function setDebugSession(
   } else {
     debug.session.client = client;
   }
-  await debug.session.restoreState();
-  if (debug.canStart()) {
-    await debug.start();
-  }
+  await debug.restoreState(true);
   app.commands.notifyCommandChanged();
 }
 
@@ -281,9 +278,7 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
         sidebar.title.label = 'Environment';
         shell.add(sidebar, 'right', { activate: false });
 
-        if (service.canStart()) {
-          await service.start();
-        }
+        await service.restoreState(true);
       }
     });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -56,6 +56,7 @@ export class DebugService implements IDebugger {
 
   set model(model: Debugger.Model) {
     this._model = model;
+    this._modelChanged.emit(model);
   }
 
   get session(): IDebugger.ISession {
@@ -139,6 +140,10 @@ export class DebugService implements IDebugger {
 
   get sessionChanged(): ISignal<IDebugger, IDebugger.ISession> {
     return this._sessionChanged;
+  }
+
+  get modelChanged(): ISignal<IDebugger, Debugger.Model> {
+    return this._modelChanged;
   }
 
   get eventMessage(): ISignal<IDebugger, IDebugger.ISession.Event> {
@@ -286,6 +291,7 @@ export class DebugService implements IDebugger {
   private _isDisposed: boolean = false;
   private _session: IDebugger.ISession;
   private _sessionChanged = new Signal<IDebugger, IDebugger.ISession>(this);
+  private _modelChanged = new Signal<IDebugger, Debugger.Model>(this);
   private _eventMessage = new Signal<IDebugger, IDebugger.ISession.Event>(this);
   private _model: Debugger.Model;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -45,9 +45,9 @@ export class DebugSession implements IDebugger.ISession {
       return;
     }
 
-    if (this._client) {
+    /*if (this._client) {
       Signal.clearData(this._client);
-    }
+    }*/
 
     this._client = client;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -138,13 +138,15 @@ export class DebugSession implements IDebugger.ISession {
   /**
    * Restore the state of a debug session.
    */
-  async restoreState(): Promise<void> {
+  async restoreState(): Promise<IDebugger.ISession.Response['debugInfo']> {
     await this.client.ready;
     try {
       const message = await this.sendRequest('debugInfo', {});
       this._isStarted = message.body.isStarted;
+      return message;
     } catch (err) {
       console.error('Error: ', err.message);
+      return null;
     }
   }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -96,6 +96,11 @@ export interface IDebugger {
   sessionChanged: ISignal<IDebugger, IDebugger.ISession>;
 
   /**
+   * Signal emitted upon model changed.
+   */
+  modelChanged: ISignal<IDebugger, Debugger.Model>;
+
+  /**
    * Signal emitted for debug event messages.
    */
   eventMessage: ISignal<IDebugger, IDebugger.ISession.Event>;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -71,6 +71,11 @@ export interface IDebugger {
   stop(): Promise<void>;
 
   /**
+   * Restore the state of a debug session.
+   */
+  restoreState(autoStart: boolean): Promise<void>;
+
+  /**
    * Continues the execution of the current thread.
    */
   continue(): Promise<void>;
@@ -147,7 +152,7 @@ export namespace IDebugger {
     /**
      * Restore the state of a debug session.
      */
-    restoreState(): Promise<void>;
+    restoreState(): Promise<IDebugger.ISession.Response['debugInfo']>;
 
     /**
      * Send a debug request to the kernel.
@@ -202,6 +207,8 @@ export namespace IDebugger {
         isStarted: boolean;
         hashMethod: string;
         hashSeed: number;
+        tmp_file_prefix: string;
+        tmp_file_suffix: string;
         breakpoints: IDebugInfoBreakpoints[];
       };
     }


### PR DESCRIPTION
This is an overview of what the breakpoint model could look like if we want it to track all the breakpoints of a notebook and restore them properly. I will split this PR into smaller ones so that it is easier to merge them (and also to take #139 into account), however review and comments on this one would be much appreciated. Remaining issues / questions for now:

- There is a bug in the breakpoint panel, when switching from a notebook with breakpoints to another notebook with breakpoints, sometimes a breakpoint appears twice or the breakpoints of both notebooks are merged. I guess this is due to the way react updates the component, but my limited skills in react do not allow me to understand what is going on

- I had to remove the Signal.clearData call when changing the client of a session, otherwise the events are not caught anymore when switching from a notebook to another but I am affraid that this would lead to stacking a lot of slots.

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JohanMabille/debugger/notebook_bp?urlpath=lab/tree/examples/index.ipynb)