### PR TITLE
Add the stop button to the callstack toolbar

### DIFF
--- a/src/callstack/index.ts
+++ b/src/callstack/index.ts
@@ -34,6 +34,14 @@ export class Callstack extends Panel {
     );
 
     header.toolbar.addItem(
+      'terminate',
+      new CommandToolbarButton({
+        commands: commands.registry,
+        id: commands.terminate
+      })
+    );
+
+    header.toolbar.addItem(
       'step-over',
       new CommandToolbarButton({
         commands: commands.registry,
@@ -127,6 +135,11 @@ export namespace Callstack {
      * The continue command ID.
      */
     continue: string;
+
+    /**
+     * The terminate command ID.
+     */
+    terminate: string;
 
     /**
      * The next / stepOver command ID.

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,8 +299,7 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
         return service.isThreadStopped();
       },
       execute: async () => {
-        await service.stop();
-        await service.start();
+        await service.restart();
         commands.notifyCommandChanged();
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,8 +65,6 @@ export namespace CommandIDs {
 
   export const debugFile = 'debugger:debug-file';
 
-  export const debugNotebook = 'debugger:debug-notebook';
-
   export const mount = 'debugger:mount';
 
   export const changeMode = 'debugger:change-mode';
@@ -411,13 +409,17 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
 
     if (palette) {
       const category = 'Debugger';
-      palette.addItem({ command: CommandIDs.changeMode, category });
-      palette.addItem({ command: CommandIDs.create, category });
-      palette.addItem({ command: CommandIDs.debugContinue, category });
-      palette.addItem({ command: CommandIDs.next, category });
-      palette.addItem({ command: CommandIDs.stepIn, category });
-      palette.addItem({ command: CommandIDs.stepOut, category });
-      palette.addItem({ command: CommandIDs.debugNotebook, category });
+      [
+        CommandIDs.changeMode,
+        CommandIDs.create,
+        CommandIDs.debugContinue,
+        CommandIDs.terminate,
+        CommandIDs.next,
+        CommandIDs.stepIn,
+        CommandIDs.stepOut
+      ].forEach(command => {
+        palette.addItem({ command, category });
+      });
     }
 
     if (restorer) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ export namespace CommandIDs {
 
   export const debugContinue = 'debugger:continue';
 
+  export const terminate = 'debugger:terminate';
+
   export const next = 'debugger:next';
 
   export const stepIn = 'debugger:stepIn';
@@ -291,6 +293,20 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
       }
     });
 
+    commands.addCommand(CommandIDs.terminate, {
+      label: 'Terminate',
+      caption: 'Terminate',
+      iconClass: 'jp-MaterialIcon jp-StopIcon',
+      isEnabled: () => {
+        return service.isThreadStopped();
+      },
+      execute: async () => {
+        await service.stop();
+        await service.start();
+        commands.notifyCommandChanged();
+      }
+    });
+
     commands.addCommand(CommandIDs.next, {
       label: 'Next',
       caption: 'Next',
@@ -350,6 +366,7 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
         const callstackCommands = {
           registry: commands,
           continue: CommandIDs.debugContinue,
+          terminate: CommandIDs.terminate,
           next: CommandIDs.next,
           stepIn: CommandIDs.stepIn,
           stepOut: CommandIDs.stepOut

--- a/src/service.ts
+++ b/src/service.ts
@@ -81,10 +81,10 @@ export class DebugService implements IDebugger {
 
     this._session.eventMessage.connect((_, event) => {
       if (event.event === 'stopped') {
-        this._threadStopped.add(event.body.threadId);
+        this._stoppedThreads.add(event.body.threadId);
         void this.getAllFrames();
       } else if (event.event === 'continued') {
-        this._threadStopped.delete(event.body.threadId);
+        this._stoppedThreads.delete(event.body.threadId);
         this.clearModel();
       }
       this._eventMessage.emit(event);
@@ -151,7 +151,7 @@ export class DebugService implements IDebugger {
    * Whether the current thread is stopped.
    */
   isThreadStopped(): boolean {
-    return this._threadStopped.has(this.currentThread());
+    return this._stoppedThreads.has(this.currentThread());
   }
 
   /**
@@ -169,7 +169,7 @@ export class DebugService implements IDebugger {
   async stop(): Promise<void> {
     await this.session.stop();
     this.clearModel();
-    this._threadStopped.clear();
+    this._stoppedThreads.clear();
   }
 
   /**
@@ -199,7 +199,7 @@ export class DebugService implements IDebugger {
       await this.session.sendRequest('continue', {
         threadId: this.currentThread()
       });
-      this._threadStopped.delete(this.currentThread());
+      this._stoppedThreads.delete(this.currentThread());
     } catch (err) {
       console.error('Error:', err.message);
     }
@@ -396,7 +396,7 @@ export class DebugService implements IDebugger {
   private frames: Frame[] = [];
 
   // TODO: move this in model
-  private _threadStopped = new Set();
+  private _stoppedThreads = new Set();
 }
 
 export type Frame = {

--- a/src/service.ts
+++ b/src/service.ts
@@ -177,10 +177,12 @@ export class DebugService implements IDebugger {
    * Precondition: isStarted() and stopped.
    */
   async restart(): Promise<void> {
+    const breakpoints = this.model.breakpointsModel.breakpoints;
     await this.stop();
     this.clearModel();
     this._stoppedThreads.clear();
     await this.start();
+    await this.updateBreakpoints(breakpoints);
   }
 
   /**
@@ -258,7 +260,7 @@ export class DebugService implements IDebugger {
   /**
    * Update all breakpoints at once.
    */
-  updateBreakpoints = async (breakpoints: Breakpoints.IBreakpoint[]) => {
+  async updateBreakpoints(breakpoints: Breakpoints.IBreakpoint[]) {
     if (!this.session.isStarted) {
       return;
     }
@@ -286,7 +288,7 @@ export class DebugService implements IDebugger {
     );
     this._model.breakpointsModel.breakpoints = kernelBreakpoints;
     await this.session.sendRequest('configurationDone', {});
-  };
+  }
 
   getAllFrames = async () => {
     const stackFrames = await this.getFrames(this.currentThread());

--- a/src/service.ts
+++ b/src/service.ts
@@ -85,7 +85,7 @@ export class DebugService implements IDebugger {
         void this.getAllFrames();
       } else if (event.event === 'continued') {
         this._threadStopped.delete(event.body.threadId);
-        this.onContinued();
+        this.clearModel();
       }
       this._eventMessage.emit(event);
     });
@@ -168,6 +168,8 @@ export class DebugService implements IDebugger {
    */
   async stop(): Promise<void> {
     await this.session.stop();
+    this.clearModel();
+    this._threadStopped.clear();
   }
 
   /**
@@ -373,7 +375,7 @@ export class DebugService implements IDebugger {
     return client.ready;
   }
 
-  private onContinued() {
+  private clearModel() {
     this._model.callstackModel.frames = [];
     this._model.variablesModel.scopes = [];
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -168,8 +168,6 @@ export class DebugService implements IDebugger {
    */
   async stop(): Promise<void> {
     await this.session.stop();
-    this.clearModel();
-    this._stoppedThreads.clear();
   }
 
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -173,6 +173,17 @@ export class DebugService implements IDebugger {
   }
 
   /**
+   * Restarts the debugger.
+   * Precondition: isStarted() and stopped.
+   */
+  async restart(): Promise<void> {
+    await this.stop();
+    this.clearModel();
+    this._stoppedThreads.clear();
+    await this.start();
+  }
+
+  /**
    * Restore the state of a debug session.
    * @param autoStart - when true, starts the debugger
    * if it has not been started yet.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -79,6 +79,12 @@ export interface IDebugger extends IDisposable {
   stop(): Promise<void>;
 
   /**
+   * Restart the debugger.
+   * Precondition: isStarted()
+   */
+  restart(): Promise<void>;
+
+  /**
    * Restore the state of a debug session.
    * @param autoStart - when true, starts the debugger
    * if it has not been started yet.

--- a/tests/src/debugger.spec.ts
+++ b/tests/src/debugger.spec.ts
@@ -24,6 +24,7 @@ describe('Debugger', () => {
       callstackCommands: {
         registry,
         continue: '',
+        terminate: '',
         next: '',
         stepIn: '',
         stepOut: ''


### PR DESCRIPTION
Fixes #155 

There doesn't seem to be any straightforward way to continue the execution of a cell while ignoring all the breakpoints.

Altering the debug session state (removing and re-adding the breakpoints) could work, but could lead to edge cases such as the page being reloaded and losing all the breakpoints.

Another approach would be to support `disabled` breakpoints (#128):
- Click on `stop`
- Disable all breakpoints
- Wait for `execution_reply`
- Enable all breakpoints (or only the ones that were enabled before the `stop`)

### TODO

- [x] Add the `stop` button
- [x] Clear the UI on `stop`
- [x] Send breakpoints after restarting the debugger

![stop-button-3](https://user-images.githubusercontent.com/591645/68316125-34064f80-00b9-11ea-9788-47ce37c86597.gif)
