### PR TITLE
Remove onNewRenderLine

### DIFF
--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -118,22 +118,6 @@ export namespace Breakpoints {
       this.breakpoints = this._state[newType];
     }
 
-    changeLines(lines: number[]) {
-      if (!lines && this.breakpoints.length === 0) {
-        return;
-      }
-      if (lines.length === 0) {
-        this.breakpoints = [];
-      } else {
-        const breakpoint = { ...this.breakpoints[0] };
-        let breakpoints: Breakpoints.IBreakpoint[] = [];
-        lines.forEach(line => {
-          breakpoints.push({ ...breakpoint, line });
-        });
-        this.breakpoints = [...breakpoints];
-      }
-    }
-
     get isDisposed(): boolean {
       return this._isDisposed;
     }


### PR DESCRIPTION
Fixes #159.

Not exactly sure why we had this in the first place. But the `onNewRenderLine` was modifying the breakpoints model directly and triggering CodeMirror issues (#159).

Instead we'll want to send the `dumpCell` and `setBreakpoints` requests via the service when a user modifies the content of a cell.

![remove-renderline](https://user-images.githubusercontent.com/591645/68383177-74b3a680-0155-11ea-8219-d385092751da.gif)
