### PR TITLE
Add tests for the DebugService

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ export XEUS_LOG=1
 jlpm run test
 ```
 
+To run tests for a specific test suite name:
+
+```bash
+jlpm run test --testNamePattern=<regex>
+```
+
+To run tests for a specific test module name:
+
+```bash
+jlpm run test --testPathPattern=<regex>
+```
+
 ### Inspecting debug messages
 
 The [kernelspy extension for JupyterLab](https://github.com/vidartf/jupyterlab-kernelspy) can be used to inspect the debug messages sent between the debugger UI and the kernel.

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -1,13 +1,66 @@
 import { expect } from 'chai';
 
+import { ClientSession, IClientSession } from '@jupyterlab/apputils';
+
+import { createClientSession } from '@jupyterlab/testutils';
+
 import { DebugService } from '../../lib/service';
 
+import { DebugSession } from '../../lib/session';
+
+import { IDebugger } from '../../lib/tokens';
+
 describe('DebugService', () => {
-  let service = new DebugService();
+  let client: IClientSession;
+  let session: IDebugger.ISession;
+  let service: IDebugger;
+
+  beforeEach(async () => {
+    client = await createClientSession({
+      kernelPreference: {
+        name: 'xpython'
+      }
+    });
+    await (client as ClientSession).initialize();
+    await client.kernel.ready;
+    session = new DebugSession({ client });
+    service = new DebugService();
+  });
+
+  afterEach(async () => {
+    await client.shutdown();
+    session.dispose();
+    service.dispose();
+  });
 
   describe('#constructor()', () => {
     it('should create a new instance', () => {
       expect(service).to.be.an.instanceOf(DebugService);
+    });
+  });
+
+  describe('#start()', () => {
+    it('should start the service if the session is set', async () => {
+      service.session = session;
+      await service.start();
+      expect(service.isStarted()).to.equal(true);
+    });
+
+    it('should throw an error if the session is not set', async () => {
+      try {
+        await service.start();
+      } catch (err) {
+        expect(err.message).to.contain("Cannot read property 'start' of null");
+      }
+    });
+  });
+
+  describe('#stop()', () => {
+    it('should stop the service if the session is set', async () => {
+      service.session = session;
+      await service.start();
+      await service.stop();
+      expect(service.isStarted()).to.equal(false);
     });
   });
 });

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -63,4 +63,16 @@ describe('DebugService', () => {
       expect(service.isStarted()).to.equal(false);
     });
   });
+
+  describe('#session', () => {
+    it('should emit the sessionChanged event setting the session', () => {
+      let sessionChangedEvents: IDebugger.ISession[] = [];
+      service.sessionChanged.connect((_, newSession) => {
+        sessionChangedEvents.push(newSession);
+      });
+      service.session = session;
+      expect(sessionChangedEvents.length).to.equal(1);
+      expect(sessionChangedEvents[0]).to.eq(session);
+    });
+  });
 });

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -4,6 +4,8 @@ import { ClientSession, IClientSession } from '@jupyterlab/apputils';
 
 import { createClientSession } from '@jupyterlab/testutils';
 
+import { Debugger } from '../../lib/debugger';
+
 import { DebugService } from '../../lib/service';
 
 import { DebugSession } from '../../lib/session';
@@ -12,6 +14,7 @@ import { IDebugger } from '../../lib/tokens';
 
 describe('DebugService', () => {
   let client: IClientSession;
+  let model: Debugger.Model;
   let session: IDebugger.ISession;
   let service: IDebugger;
 
@@ -24,6 +27,7 @@ describe('DebugService', () => {
     await (client as ClientSession).initialize();
     await client.kernel.ready;
     session = new DebugSession({ client });
+    model = new Debugger.Model({});
     service = new DebugService();
   });
 
@@ -65,7 +69,7 @@ describe('DebugService', () => {
   });
 
   describe('#session', () => {
-    it('should emit the sessionChanged event setting the session', () => {
+    it('should emit the sessionChanged signal when setting the session', () => {
       let sessionChangedEvents: IDebugger.ISession[] = [];
       service.sessionChanged.connect((_, newSession) => {
         sessionChangedEvents.push(newSession);
@@ -73,6 +77,18 @@ describe('DebugService', () => {
       service.session = session;
       expect(sessionChangedEvents.length).to.equal(1);
       expect(sessionChangedEvents[0]).to.eq(session);
+    });
+  });
+
+  describe('#model', () => {
+    it('should emit the modelChanged signal when setting the model', () => {
+      let modelChangedEvents: Debugger.Model[] = [];
+      service.modelChanged.connect((_, newModel) => {
+        modelChangedEvents.push(newModel);
+      });
+      service.model = model;
+      expect(modelChangedEvents.length).to.equal(1);
+      expect(modelChangedEvents[0]).to.eq(model);
     });
   });
 });

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+
+import { DebugService } from '../../lib/service';
+
+describe('DebugService', () => {
+  let service = new DebugService();
+
+  describe('#constructor()', () => {
+    it('should create a new instance', () => {
+      expect(service).to.be.an.instanceOf(DebugService);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #158.

```bash
jlpm run build && jlpm run test --testPathPatten="service\.spec\.ts"
```

### TODO

- [x] Add instructions to the README to run specific tests
- [x] Add scaffolding for testing the `DebugService`
- [x] Test `start` and `stop`
- [x] Test signals are emitted