### PR TITLE
Update breakpoints on cell content changed

### DIFF
--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -139,11 +139,40 @@ export class CellManager implements IDisposable {
       this._debuggerService.session
     ) {
       if (this.previousCell && !this.previousCell.isDisposed) {
+        this.previousCell.model.contentChanged.disconnect(
+          this.sendEditorBreakpoints,
+          this
+        );
         this.removeListener(this.previousCell);
       }
+      this.activeCell.model.contentChanged.connect(
+        this.sendEditorBreakpoints,
+        this
+      );
       this.previousCell = this.activeCell;
       this.setEditor(this.activeCell);
     }
+  }
+
+  protected sendEditorBreakpoints() {
+    // TODO: put behind a Debouncer / ActivityMonitor
+    const cell = this.activeCell;
+    if (!cell || !cell.editor) {
+      return;
+    }
+
+    const breakpoints = this.getBreakpointsFromEditor(cell).map(lineInfo => {
+      return Private.createBreakpoint(
+        this._debuggerService.session.client.name,
+        this.getEditorId(),
+        lineInfo.line + 1
+      );
+    });
+
+    void this._debuggerService.updateBreakpoints(
+      cell.editor.model.value.text,
+      breakpoints
+    );
   }
 
   protected setEditor(cell: CodeCell) {
@@ -214,6 +243,18 @@ export class CellManager implements IDisposable {
         Private.createMarkerNode()
       );
     });
+  }
+
+  private getBreakpointsFromEditor(cell: CodeCell): ILineInfo[] {
+    const editor = cell.editor as CodeMirrorEditor;
+    let lines = [];
+    for (let i = 0; i < editor.doc.lineCount(); i++) {
+      const info = editor.editor.lineInfo(i);
+      if (info.gutterMarkers) {
+        lines.push(info);
+      }
+    }
+    return lines;
   }
 
   private getBreakpoints(cell: CodeCell): Breakpoints.IBreakpoint[] {

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -167,7 +167,6 @@ export class CellManager implements IDisposable {
   }
 
   protected sendEditorBreakpoints() {
-    // TODO: put behind a Debouncer / ActivityMonitor
     const cell = this.activeCell;
     if (!cell || !cell.editor) {
       return;


### PR DESCRIPTION
Fixes #162.

The idea is to send the content of the cell and the list of breakpoints to the kernel, so that the next `execute_request` will be able to break using the up-to-date cell code.

![cell-activity](https://user-images.githubusercontent.com/591645/68487526-84a9b400-0243-11ea-85f3-8c6a49bd132b.gif)

### TODO

- [x] Update breakpoints on cell content changed
- [x] Use an `ActivityMonitor` (or `Debouncer`) to throttle the updates