### PR TITLE
Add tests for source and loadedSources

### DIFF
--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -262,4 +262,31 @@ describe('protocol', () => {
       expect(j.value).to.equal('4');
     });
   });
+
+  describe('#loadedSources', () => {
+    it('should retrieve the list of loaded sources', async () => {
+      const loadedSourcesReply = await debugSession.sendRequest(
+        'loadedSources',
+        {}
+      );
+      const sources = loadedSourcesReply.body.sources;
+      expect(sources).to.exist;
+      expect(sources.length).to.be.above(0);
+    });
+  });
+
+  describe('#source', () => {
+    it('should retrieve the source of the dumped code cell', async () => {
+      const stackFramesReply = await debugSession.sendRequest('stackTrace', {
+        threadId
+      });
+      const frame = stackFramesReply.body.stackFrames[0];
+      const source = frame.source;
+      const reply = await debugSession.sendRequest('source', {
+        sourceReference: source.sourceReference
+      });
+      const sourceCode = reply.body.content;
+      expect(sourceCode).to.equal(code);
+    });
+  });
 });

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -264,14 +264,10 @@ describe('protocol', () => {
   });
 
   describe('#loadedSources', () => {
-    it('should retrieve the list of loaded sources', async () => {
-      const loadedSourcesReply = await debugSession.sendRequest(
-        'loadedSources',
-        {}
-      );
-      const sources = loadedSourcesReply.body.sources;
-      expect(sources).to.exist;
-      expect(sources.length).to.be.above(0);
+    it('should *not* retrieve the list of loaded sources', async () => {
+      // `loadedSources` is not supported at the moment "unknown command"
+      const reply = await debugSession.sendRequest('loadedSources', {});
+      expect(reply.success).to.be.false;
     });
   });
 
@@ -283,6 +279,7 @@ describe('protocol', () => {
       const frame = stackFramesReply.body.stackFrames[0];
       const source = frame.source;
       const reply = await debugSession.sendRequest('source', {
+        source: { path: source.path },
         sourceReference: source.sourceReference
       });
       const sourceCode = reply.body.content;


### PR DESCRIPTION
This change adds two tests for the `DebugSession`.

This is in preparation for #169, and to test whether it is possible to retrieve the content for a `DebugProtocol.Source`.

At the moment the tests fail for both the `loadedSources` and `sources` request:

```
D00000.415: (while handling {'command': 'loadedSources', 'seq': 5, 'type': 'request'})
            IDE <-- {
                "type": "response",
                "seq": 9,
                "request_seq": 5,
                "success": false,
                "command": "loadedSources",
                "message": "Unknown command",
                "body": {}
            }
```

```
D00000.599: (requested while handling {'command': 'source', 'seq': 7, 'type': 'request'})
            PYD --> {
                "type": "response",
                "request_seq": 1000000005,
                "success": false,
                "command": "source",
                "body": {
                    "content": ""
                },
                "seq": 22,
                "message": "Source unavailable",
                "pydevd_cmd_id": 502
            }
```