### PR TITLE
Add the sidebar to the layout restorer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -277,6 +277,10 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
         sidebar.title.label = 'Environment';
         shell.add(sidebar, 'right', { activate: false });
 
+        if (restorer) {
+          restorer.add(sidebar, 'debugger-sidebar');
+        }
+
         await service.restoreState(true);
       }
     });


### PR DESCRIPTION
This should fix #96.

Add the sidebar to the layout restorer so it can be restored in the right area on page reload, and serializes it in the workspace file:

```json
"right": {
	"collapsed": false,
	"current": "debugger-sidebar",
	"widgets": [
	  "debugger-sidebar"
	]
}
```

![restore-sidebar-state2](https://user-images.githubusercontent.com/591645/68937539-d8188680-079c-11ea-85ea-15519fc32d39.gif)
