### PR TITLE
Initial support for handling messages for other cells

### DIFF
--- a/examples/index.ipynb
+++ b/examples/index.ipynb
@@ -13,6 +13,17 @@
     "result = add(1, 2)\n",
     "print(result)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "i = 0\n",
+    "i += 1\n",
+    "print(i)"
+   ]
   }
  ],
  "metadata": {

--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -273,12 +273,21 @@ export namespace CellManager {
     type: SessionTypes;
   }
 
+  /**
+   * Highlight the current line of the frame in the given cell.
+   * @param cell The cell to highlight.
+   * @param frame The frame with the current line number.
+   */
   export function showCurrentLine(cell: Cell, frame: Callstack.IFrame) {
     const editor = cell.editor as CodeMirrorEditor;
     cleanupHighlight(cell);
     editor.editor.addLineClass(frame.line - 1, 'wrap', LINE_HIGHLIGHT_CLASS);
   }
 
+  /**
+   * Remove all line highlighting indicators for the given cell.
+   * @param cell The cell to cleanup.
+   */
   export function cleanupHighlight(cell: Cell) {
     if (!cell || cell.isDisposed) {
       return;

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -84,13 +84,14 @@ export class NotebookHandler implements IDisposable {
       return;
     }
 
-    cells.forEach(cell => {
+    cells.forEach((cell, i) => {
       // check the event is for the correct cell
       const code = cell.model.value.text;
       const cellId = this.debuggerService.getCellId(code);
       if (frame.source.path !== cellId) {
         return;
       }
+      notebook.content.activeCellIndex = i;
       CellManager.showCurrentLine(cell, frame);
     });
   }

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -41,9 +41,8 @@ export class NotebookHandler implements IDisposable {
     );
 
     this.debuggerModel.callstackModel.currentFrameChanged.connect(
-      (_, frame) => {
-        this.showCurrentLine(frame);
-      }
+      this.onCurrentFrameChanged,
+      this
     );
   }
 
@@ -71,7 +70,10 @@ export class NotebookHandler implements IDisposable {
     });
   }
 
-  private showCurrentLine(frame: Callstack.IFrame) {
+  private onCurrentFrameChanged(
+    callstackModel: Callstack.Model,
+    frame: Callstack.IFrame
+  ) {
     const notebook = this.notebookTracker.currentWidget;
     if (!notebook) {
       return;

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -72,16 +72,17 @@ export class NotebookHandler implements IDisposable {
   }
 
   private showCurrentLine(frame: Callstack.IFrame) {
-    if (!frame) {
-      return;
-    }
-
     const notebook = this.notebookTracker.currentWidget;
     if (!notebook) {
       return;
     }
 
     const cells = notebook.content.widgets;
+    cells.forEach(cell => CellManager.cleanupHighlight(cell));
+
+    if (!frame) {
+      return;
+    }
 
     cells.forEach(cell => {
       // check the event is for the correct cell


### PR DESCRIPTION
This will fix #121.

There will still be more to refactor afterwards. Ideally we should be able to jump to any cells that are tracked by the debugger plugins. The logic could be shared between the notebook and console handlers.

Opening the content of the file / cell when it cannot be found in the current widgets can be done in #169.

### TODO

- [x] Find the cell where execution has stopped using its hash
- [x] Properly cleanup the cell on debug actions (continue)
- [x] Bring focus back to the cell where execution has stopped

![run-button-jump-to-cell](https://user-images.githubusercontent.com/591645/69051673-4a8b9f80-0a05-11ea-965f-aec56be4ffd9.gif)