### PR TITLE
Add support for the debugger flag in kernel info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,9 @@ async function setDebugSession(
   } else {
     debug.session.client = client;
   }
-  await debug.restoreState(true);
+  if (debug.isDebuggingEnabled) {
+    await debug.restoreState(true);
+  }
   app.commands.notifyCommandChanged();
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -173,7 +173,7 @@ export class DebugService implements IDebugger {
 
   /**
    * Starts a debugger.
-   * Precondition: canStart() && !isStarted()
+   * Precondition: !isStarted()
    */
   async start(): Promise<void> {
     await this.session.start();

--- a/src/service.ts
+++ b/src/service.ts
@@ -43,6 +43,13 @@ export class DebugService implements IDebugger {
   }
 
   /**
+   * Whether debugging is enabled for the current session.
+   */
+  get isDebuggingEnabled(): boolean {
+    return this._session.kernelInfo.debugger || false;
+  }
+
+  /**
    * Returns the mode of the debugger UI.
    *
    * #### Notes

--- a/src/session.ts
+++ b/src/session.ts
@@ -68,6 +68,17 @@ export class DebugSession implements IDebugger.ISession {
   }
 
   /**
+   * Return the kernel info for the debug session.
+   */
+  get kernelInfo(): IDebugger.ISession.IInfoReply | null {
+    const kernel = this.client.kernel;
+    if (!kernel) {
+      return null;
+    }
+    return kernel.info as IDebugger.ISession.IInfoReply;
+  }
+
+  /**
    * Whether the debug session is started
    */
   get isStarted(): boolean {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,7 +3,7 @@
 
 import { IClientSession } from '@jupyterlab/apputils';
 
-import { Session } from '@jupyterlab/services';
+import { KernelMessage, Session } from '@jupyterlab/services';
 
 import { Token } from '@phosphor/coreutils';
 
@@ -22,6 +22,11 @@ import { Debugger } from './debugger';
  * An interface describing an application's visual debugger.
  */
 export interface IDebugger extends IDisposable {
+  /**
+   * Whether debugging is enabled for the current session.
+   */
+  readonly isDebuggingEnabled: boolean;
+
   /**
    * The mode of the debugger UI.
    *
@@ -151,9 +156,15 @@ export namespace IDebugger {
     client: IClientSession | Session.ISession;
 
     /**
+     * The kernel info for the debug session.
+     */
+    readonly kernelInfo: IDebugger.ISession.IInfoReply | null;
+
+    /**
      * Whether the debug session is started
      */
     readonly isStarted: boolean;
+
     /**
      * Signal emitted for debug event messages.
      */
@@ -187,6 +198,16 @@ export namespace IDebugger {
   }
 
   export namespace ISession {
+    /**
+     * Response to the 'kernel_info_request' request.
+     * This interface extends the IInfoReply by adding the `debugger` key
+     * that isn't part of the protocol yet.
+     * See this pull request for more info: https://github.com/jupyter/jupyter_client/pull/486
+     */
+    export interface IInfoReply extends KernelMessage.IInfoReply {
+      debugger: boolean;
+    }
+
     /**
      * Arguments for 'dumpCell' request.
      * This is an addition to the Debug Adapter Protocol to support

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -78,7 +78,7 @@ export interface IDebugger extends IDisposable {
 
   /**
    * Starts a debugger.
-   * Precondition: canStart() && !isStarted()
+   * Precondition: !isStarted()
    */
   start(): Promise<void>;
 


### PR DESCRIPTION
Fixes #167.

### TODO

- [x] Add `debugger` key to the interface
- [x] ~Check debugging is enabled before starting the service~