### PR TITLE
Use the value.changed signal for the cell monitor

### DIFF
--- a/src/handlers/cell.ts
+++ b/src/handlers/cell.ts
@@ -1,11 +1,13 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Cell, CodeCell, ICellModel } from '@jupyterlab/cells';
+import { Cell, CodeCell } from '@jupyterlab/cells';
 
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
 import { ActivityMonitor } from '@jupyterlab/coreutils';
+
+import { IObservableString } from '@jupyterlab/observables';
 
 import { IDisposable } from '@phosphor/disposable';
 
@@ -135,7 +137,7 @@ export class CellManager implements IDisposable {
       }
 
       this._cellMonitor = new ActivityMonitor({
-        signal: this.activeCell.model.contentChanged,
+        signal: this.activeCell.model.value.changed,
         timeout: CELL_CHANGED_TIMEOUT
       });
 
@@ -261,7 +263,10 @@ export class CellManager implements IDisposable {
   private breakpointsModel: Breakpoints.Model;
   private _activeCell: CodeCell;
   private _debuggerService: IDebugger;
-  private _cellMonitor: ActivityMonitor<ICellModel, void> = null;
+  private _cellMonitor: ActivityMonitor<
+    IObservableString,
+    IObservableString.IChangedArgs
+  > = null;
 }
 
 export namespace CellManager {


### PR DESCRIPTION
Fixes #202.

The `value.changed` signal seems more appropriate.

![value-changed-signal](https://user-images.githubusercontent.com/591645/69138654-5dfb4100-0abf-11ea-9e0d-55e5b8299c6a.gif)
