### PR TITLE
no create handle for no supported kernels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ class DebuggerHandler<H extends ConsoleHandler | NotebookHandler> {
     T extends IConsoleTracker | INotebookTracker,
     W extends ConsolePanel | NotebookPanel
   >(debug: IDebugger, tracker: T, widget: W): void {
-    if (!debug.model || this.handlers[widget.id]) {
+    if (!debug.model || this.handlers[widget.id] || !debug.isDebuggingEnabled) {
       return;
     }
     const handler = new this.builder({


### PR DESCRIPTION
It's resolve #209 . 

But seems like during creating new widget client not have already attached kernel  (it's exist some time gap):
![issue_on_start](https://user-images.githubusercontent.com/34033913/69345490-8165ed80-0c71-11ea-89b0-9f65b924047a.gif)
