### PR TITLE
Add support for breakpoints and line highlighting in read-only editors

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -5,8 +5,6 @@ import { IEditorServices } from '@jupyterlab/codeeditor';
 
 import { IDataConnector } from '@jupyterlab/coreutils';
 
-import { IObservableString } from '@jupyterlab/observables';
-
 import { ReadonlyJSONValue } from '@phosphor/coreutils';
 
 import { Message } from '@phosphor/messaging';
@@ -174,14 +172,6 @@ export namespace Debugger {
       return this._modeChanged;
     }
 
-    get codeValue() {
-      return this._codeValue;
-    }
-
-    set codeValue(observableString: IObservableString) {
-      this._codeValue = observableString;
-    }
-
     private async _populate(): Promise<void> {
       const { connector } = this;
 
@@ -190,7 +180,6 @@ export namespace Debugger {
       }
     }
 
-    private _codeValue: IObservableString;
     private _isDisposed = false;
     private _mode: IDebugger.Mode;
     private _stoppedThreads = new Set<number>();

--- a/src/editors/index.ts
+++ b/src/editors/index.ts
@@ -30,6 +30,10 @@ export class DebuggerEditors extends TabPanel {
 
     this.tabsMovable = true;
     this.tabBar.insertBehavior = 'select-tab';
+    this.tabBar.tabCloseRequested.connect((_, tab) => {
+      const widget = tab.title.owner;
+      widget.dispose();
+    });
 
     this.model = new DebuggerEditors.IModel();
 
@@ -137,12 +141,9 @@ export class DebuggerEditors extends TabPanel {
       editor: editor.editor
     });
 
-    // TODO: define the signal only once
-    this.tabBar.tabCloseRequested.connect((_, tab) => {
-      const widget = tab.title.owner;
-      widget.dispose();
+    editor.disposed.connect(() => {
       editorHandler.dispose();
-      this.model.removeEditor(tab.title.label);
+      this.model.removeEditor(editor.title.label);
     });
 
     this.addWidget(editor);

--- a/src/handlers/console.ts
+++ b/src/handlers/console.ts
@@ -9,25 +9,23 @@ import { IDisposable } from '@phosphor/disposable';
 
 import { Signal } from '@phosphor/signaling';
 
-import { Breakpoints } from '../breakpoints';
-
 import { EditorHandler } from '../handlers/editor';
 
-import { IDebugger } from '../tokens';
-
 import { Debugger } from '../debugger';
+
+import { IDebugger } from '../tokens';
 
 export class ConsoleHandler implements IDisposable {
   constructor(options: DebuggerConsoleHandler.IOptions) {
     this.debuggerModel = options.debuggerService.model as Debugger.Model;
     this.debuggerService = options.debuggerService;
     this.consoleTracker = options.tracker;
-    this.breakpoints = this.debuggerModel.breakpointsModel;
+
+    const promptCell = this.consoleTracker.currentWidget.console.promptCell;
     this.editorHandler = new EditorHandler({
-      activeCell: this.consoleTracker.currentWidget.console.promptCell,
-      breakpointsModel: this.breakpoints,
       debuggerModel: this.debuggerModel,
-      debuggerService: this.debuggerService
+      debuggerService: this.debuggerService,
+      editor: promptCell.editor
     });
     this.consoleTracker.currentWidget.console.promptCellCreated.connect(
       this.promptCellCreated,
@@ -47,14 +45,13 @@ export class ConsoleHandler implements IDisposable {
   }
 
   protected promptCellCreated(sender: CodeConsole, update: CodeCell) {
-    this.editorHandler.previousCell = this.editorHandler.activeCell;
-    this.editorHandler.activeCell = update;
+    // TODO: check if the previous editor must be disposed
+    // for the console
   }
 
   private consoleTracker: IConsoleTracker;
   private debuggerModel: Debugger.Model;
   private debuggerService: IDebugger;
-  private breakpoints: Breakpoints.Model;
   private editorHandler: EditorHandler;
 }
 

--- a/src/handlers/console.ts
+++ b/src/handlers/console.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { CodeConsole, IConsoleTracker } from '@jupyterlab/console';
+import { CodeConsole, ConsolePanel } from '@jupyterlab/console';
 
 import { CodeCell } from '@jupyterlab/cells';
 
@@ -19,15 +19,16 @@ export class ConsoleHandler implements IDisposable {
   constructor(options: DebuggerConsoleHandler.IOptions) {
     this.debuggerModel = options.debuggerService.model as Debugger.Model;
     this.debuggerService = options.debuggerService;
-    this.consoleTracker = options.tracker;
+    this.consolePanel = options.widget;
 
-    const promptCell = this.consoleTracker.currentWidget.console.promptCell;
+    const promptCell = this.consolePanel.console.promptCell;
     this.editorHandler = new EditorHandler({
       debuggerModel: this.debuggerModel,
       debuggerService: this.debuggerService,
       editor: promptCell.editor
     });
-    this.consoleTracker.currentWidget.console.promptCellCreated.connect(
+
+    this.consolePanel.console.promptCellCreated.connect(
       this.promptCellCreated,
       this
     );
@@ -49,7 +50,7 @@ export class ConsoleHandler implements IDisposable {
     // for the console
   }
 
-  private consoleTracker: IConsoleTracker;
+  private consolePanel: ConsolePanel;
   private debuggerModel: Debugger.Model;
   private debuggerService: IDebugger;
   private editorHandler: EditorHandler;
@@ -58,6 +59,6 @@ export class ConsoleHandler implements IDisposable {
 export namespace DebuggerConsoleHandler {
   export interface IOptions {
     debuggerService: IDebugger;
-    tracker: IConsoleTracker;
+    widget: ConsolePanel;
   }
 }

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -43,6 +43,8 @@ export class EditorHandler implements IDisposable {
     this._editorMonitor.activityStopped.connect(() => {
       this.sendEditorBreakpoints();
     }, this);
+
+    this.setup();
   }
 
   isDisposed: boolean;
@@ -54,14 +56,9 @@ export class EditorHandler implements IDisposable {
     }
     this.breakpointsModel = this._debuggerModel.breakpointsModel;
 
-    this._debuggerModel.callstackModel.currentFrameChanged.connect(
-      (_, frame) => {
-        EditorHandler.clearHighlight(this._editor);
-        if (!frame) {
-          return;
-        }
-      }
-    );
+    this._debuggerModel.callstackModel.currentFrameChanged.connect(() => {
+      EditorHandler.clearHighlight(this._editor);
+    });
 
     this.breakpointsModel.changed.connect(async () => {
       if (!this._editor || this._editor.isDisposed) {
@@ -85,7 +82,7 @@ export class EditorHandler implements IDisposable {
     this._editorMonitor.dispose();
     this.removeGutterClick();
     EditorHandler.clearHighlight(this._editor);
-    EditorHandler.clearGutter(this._editor);
+    // EditorHandler.clearGutter(this._editor);
     Signal.clearData(this);
     this.isDisposed = true;
   }
@@ -173,7 +170,7 @@ export class EditorHandler implements IDisposable {
     const breakpoints = this.getBreakpoints();
     if (
       breakpoints.length === 0 &&
-      this._id === this._debuggerService.session.client.name
+      this._id === this._debuggerService.session.client.path
     ) {
       EditorHandler.clearGutter(editor);
     } else {

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -143,8 +143,6 @@ export class EditorHandler implements IDisposable {
     }
 
     editor.focus();
-    EditorHandler.clearGutter(this._editor);
-
     const isRemoveGutter = !!info.gutterMarkers;
     let breakpoints: IDebugger.IBreakpoint[] = this.getBreakpoints();
     if (isRemoveGutter) {

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -81,8 +81,6 @@ export class EditorHandler implements IDisposable {
     }
     this._editorMonitor.dispose();
     this.removeGutterClick();
-    EditorHandler.clearHighlight(this._editor);
-    // EditorHandler.clearGutter(this._editor);
     Signal.clearData(this);
     this.isDisposed = true;
   }

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -168,20 +168,17 @@ export class EditorHandler implements IDisposable {
   private addBreakpointsToEditor() {
     const editor = this._editor as CodeMirrorEditor;
     const breakpoints = this.getBreakpoints();
-    if (
-      breakpoints.length === 0 &&
-      this._id === this._debuggerService.session.client.path
-    ) {
-      EditorHandler.clearGutter(editor);
-    } else {
-      breakpoints.forEach(breakpoint => {
-        editor.editor.setGutterMarker(
-          breakpoint.line - 1,
-          'breakpoints',
-          Private.createMarkerNode()
-        );
-      });
+    if (this._id !== this._debuggerService.session.client.path) {
+      return;
     }
+    EditorHandler.clearGutter(editor);
+    breakpoints.forEach(breakpoint => {
+      editor.editor.setGutterMarker(
+        breakpoint.line - 1,
+        'breakpoints',
+        Private.createMarkerNode()
+      );
+    });
   }
 
   private getBreakpointsFromEditor(): ILineInfo[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,26 +95,26 @@ class DebuggerHandler<H extends ConsoleHandler | NotebookHandler> {
     T extends IConsoleTracker | INotebookTracker,
     W extends ConsolePanel | NotebookPanel
   >(debug: IDebugger, tracker: T, widget: W): void {
-    if (debug.model && !this.handlers[widget.id]) {
-      const handler = new this.builder({
-        tracker: tracker,
-        debuggerService: debug,
-        id: widget.id
-      });
-      this.handlers[widget.id] = handler;
-      widget.disposed.connect(() => {
-        handler.dispose();
-        delete this.handlers[widget.id];
-      });
-
-      debug.model.disposed.connect(async () => {
-        await debug.stop();
-        Object.keys(this.handlers).forEach(id => {
-          this.handlers[id].dispose();
-        });
-        this.handlers = {};
-      });
+    if (!debug.model || this.handlers[widget.id]) {
+      return;
     }
+    const handler = new this.builder({
+      debuggerService: debug,
+      widget
+    });
+    this.handlers[widget.id] = handler;
+    widget.disposed.connect(() => {
+      handler.dispose();
+      delete this.handlers[widget.id];
+    });
+
+    debug.model.disposed.connect(async () => {
+      await debug.stop();
+      Object.keys(this.handlers).forEach(id => {
+        this.handlers[id].dispose();
+      });
+      this.handlers = {};
+    });
   }
 
   private handlers: { [id: string]: H } = {};


### PR DESCRIPTION
Fixes #200 
Fixes #211 

The goal is to make the `EditorHandler` aware of `CodeEditor.IEditor`, so we can reuse the same logic and hooks (gutter click, line highlighting and so on), when opening new editors in the main area widget.


### Changes

- Remove `codeValue` from `Debugger.Model`
- `EditorHandler` handles a `CodeEditor.IEditor` instead of a `Cell`
- Remove notebook and console trackers from the handlers (a handler is for one widget)
- Re-use the `EditorHandler` for the main area read-only editors: add support for breakpoints and line highlighting