### PR TITLE
Imodel

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -5,6 +5,7 @@ import { ReactWidget } from '@jupyterlab/apputils';
 import { ISignal } from '@phosphor/signaling';
 import React, { useEffect, useState } from 'react';
 import { Breakpoints } from '.';
+import { IDebugger } from '../tokens';
 
 export class Body extends ReactWidget {
   constructor(model: Breakpoints.Model) {
@@ -28,7 +29,7 @@ const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
   useEffect(() => {
     const updateBreakpoints = (
       _: Breakpoints.Model,
-      updates: Breakpoints.IBreakpoint[]
+      updates: IDebugger.IBreakpoint[]
     ) => {
       setBreakpoints(Array.from(model.breakpoints.entries()));
     };
@@ -64,7 +65,7 @@ const BreakpointCellComponent = ({
   breakpoints,
   model
 }: {
-  breakpoints: Breakpoints.IBreakpoint[];
+  breakpoints: IDebugger.IBreakpoint[];
   model: Breakpoints.Model;
 }) => {
   return (
@@ -73,7 +74,7 @@ const BreakpointCellComponent = ({
         .sort((a, b) => {
           return a.line - b.line;
         })
-        .map((breakpoint: Breakpoints.IBreakpoint) => (
+        .map((breakpoint: IDebugger.IBreakpoint) => (
           <BreakpointComponent
             key={breakpoint.source.path + breakpoint.line}
             breakpoint={breakpoint}
@@ -88,8 +89,8 @@ const BreakpointComponent = ({
   breakpoint,
   breakpointChanged
 }: {
-  breakpoint: Breakpoints.IBreakpoint;
-  breakpointChanged: ISignal<Breakpoints.Model, Breakpoints.IBreakpoint>;
+  breakpoint: IDebugger.IBreakpoint;
+  breakpointChanged: ISignal<Breakpoints.Model, IDebugger.IBreakpoint>;
 }) => {
   const [active, setActive] = useState(breakpoint.active);
   breakpoint.active = active;
@@ -101,7 +102,7 @@ const BreakpointComponent = ({
   useEffect(() => {
     const updateBreakpoints = (
       _: Breakpoints.Model,
-      updates: Breakpoints.IBreakpoint
+      updates: IDebugger.IBreakpoint
     ) => {
       setBreakpointEnabled(updates.active);
     };

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -7,8 +7,6 @@ import { Signal } from '@phosphor/signaling';
 
 import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 
-import { DebugProtocol } from 'vscode-debugprotocol';
-
 import { IDebugger } from '../tokens';
 
 import { Body } from './body';
@@ -81,12 +79,8 @@ class BreakpointsHeader extends Widget {
 }
 
 export namespace Breakpoints {
-  export interface IBreakpoint extends DebugProtocol.Breakpoint {
-    active: boolean;
-  }
-
   export class Model implements IDisposable {
-    get changed(): Signal<this, IBreakpoint[]> {
+    get changed(): Signal<this, IDebugger.IBreakpoint[]> {
       return this._changed;
     }
 
@@ -94,12 +88,12 @@ export namespace Breakpoints {
       return this._restored;
     }
 
-    get breakpoints(): Map<string, IBreakpoint[]> {
+    get breakpoints(): Map<string, IDebugger.IBreakpoint[]> {
       return this._breakpoints;
     }
 
     // kept for react component
-    get breakpointChanged(): Signal<this, IBreakpoint> {
+    get breakpointChanged(): Signal<this, IDebugger.IBreakpoint> {
       return this._breakpointChanged;
     }
 
@@ -115,25 +109,25 @@ export namespace Breakpoints {
       Signal.clearData(this);
     }
 
-    setBreakpoints(id: string, breakpoints: IBreakpoint[]) {
+    setBreakpoints(id: string, breakpoints: IDebugger.IBreakpoint[]) {
       this._breakpoints.set(id, breakpoints);
       this.changed.emit(breakpoints);
     }
 
-    getBreakpoints(id: string): IBreakpoint[] {
+    getBreakpoints(id: string): IDebugger.IBreakpoint[] {
       return this._breakpoints.get(id) || [];
     }
 
-    restoreBreakpoints(breakpoints: Map<string, IBreakpoint[]>) {
+    restoreBreakpoints(breakpoints: Map<string, IDebugger.IBreakpoint[]>) {
       this._breakpoints = breakpoints;
       this._restored.emit();
     }
 
-    private _breakpoints = new Map<string, IBreakpoint[]>();
-    private _changed = new Signal<this, IBreakpoint[]>(this);
+    private _breakpoints = new Map<string, IDebugger.IBreakpoint[]>();
+    private _changed = new Signal<this, IDebugger.IBreakpoint[]>(this);
     private _restored = new Signal<this, void>(this);
     // kept for react component
-    private _breakpointChanged = new Signal<this, IBreakpoint>(this);
+    private _breakpointChanged = new Signal<this, IDebugger.IBreakpoint>(this);
     private _isDisposed: boolean = false;
   }
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -9,8 +9,6 @@ import { IObservableString } from '@jupyterlab/observables';
 
 import { ReadonlyJSONValue } from '@phosphor/coreutils';
 
-import { IDisposable } from '@phosphor/disposable';
-
 import { Message } from '@phosphor/messaging';
 
 import { ISignal, Signal } from '@phosphor/signaling';
@@ -116,7 +114,7 @@ export namespace Debugger {
     readonly breakpoints: Breakpoints;
   }
 
-  export class Model implements IDisposable {
+  export class Model implements IDebugger.IModel {
     constructor(options: Debugger.Model.IOptions) {
       this.breakpointsModel = new Breakpoints.Model();
       this.callstackModel = new Callstack.Model([]);

--- a/src/handlers/console.ts
+++ b/src/handlers/console.ts
@@ -19,7 +19,7 @@ import { Debugger } from '../debugger';
 
 export class ConsoleHandler implements IDisposable {
   constructor(options: DebuggerConsoleHandler.IOptions) {
-    this.debuggerModel = options.debuggerService.model;
+    this.debuggerModel = options.debuggerService.model as Debugger.Model;
     this.debuggerService = options.debuggerService;
     this.consoleTracker = options.tracker;
     this.breakpoints = this.debuggerModel.breakpointsModel;

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -40,7 +40,7 @@ export class EditorHandler implements IDisposable {
   isDisposed: boolean;
 
   private onModelChanged() {
-    this._debuggerModel = this._debuggerService.model;
+    this._debuggerModel = this._debuggerService.model as Debugger.Model;
     if (!this._debuggerModel) {
       return;
     }

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -204,7 +204,7 @@ export class EditorHandler implements IDisposable {
     EditorHandler.clearGutter(this.activeCell);
 
     const isRemoveGutter = !!info.gutterMarkers;
-    let breakpoints: Breakpoints.IBreakpoint[] = this.getBreakpoints(
+    let breakpoints: IDebugger.IBreakpoint[] = this.getBreakpoints(
       this._activeCell
     );
     if (isRemoveGutter) {
@@ -256,7 +256,7 @@ export class EditorHandler implements IDisposable {
     return lines;
   }
 
-  private getBreakpoints(cell: CodeCell): Breakpoints.IBreakpoint[] {
+  private getBreakpoints(cell: CodeCell): IDebugger.IBreakpoint[] {
     return this._debuggerModel.breakpointsModel.getBreakpoints(
       this._debuggerService.getCellId(cell.model.value.text)
     );

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -25,7 +25,7 @@ import { EditorHandler } from './editor';
 
 export class NotebookHandler implements IDisposable {
   constructor(options: NotebookHandler.IOptions) {
-    this.debuggerModel = options.debuggerService.model;
+    this.debuggerModel = options.debuggerService.model as Debugger.Model;
     this.debuggerService = options.debuggerService;
     this.notebookTracker = options.tracker;
     this.notebookPanel = this.notebookTracker.currentWidget;

--- a/src/service.ts
+++ b/src/service.ts
@@ -15,8 +15,6 @@ import { IDebugger } from './tokens';
 
 import { Variables } from './variables';
 
-import { Breakpoints } from './breakpoints';
-
 import { Callstack } from './callstack';
 
 /**
@@ -229,7 +227,7 @@ export class DebugService implements IDebugger {
     );
 
     const breakpoints = reply.body.breakpoints;
-    let bpMap = new Map<string, Breakpoints.IBreakpoint[]>();
+    let bpMap = new Map<string, IDebugger.IBreakpoint[]>();
     if (breakpoints.length !== 0) {
       breakpoints.forEach((bp: IDebugger.ISession.IDebugInfoBreakpoints) => {
         bpMap.set(
@@ -318,10 +316,7 @@ export class DebugService implements IDebugger {
    * @param code - The code in the cell where the breakpoints are set.
    * @param breakpoints - The list of breakpoints to set.
    */
-  async updateBreakpoints(
-    code: string,
-    breakpoints: Breakpoints.IBreakpoint[]
-  ) {
+  async updateBreakpoints(code: string, breakpoints: IDebugger.IBreakpoint[]) {
     if (!this.session.isStarted) {
       return;
     }
@@ -363,7 +358,7 @@ export class DebugService implements IDebugger {
       }
     );
 
-    let bpMap = new Map<string, Breakpoints.IBreakpoint[]>();
+    let bpMap = new Map<string, IDebugger.IBreakpoint[]>();
     this._model.breakpointsModel.restoreBreakpoints(bpMap);
   }
 
@@ -533,7 +528,7 @@ export class DebugService implements IDebugger {
 }
 
 namespace Private {
-  export function toSourceBreakpoints(breakpoints: Breakpoints.IBreakpoint[]) {
+  export function toSourceBreakpoints(breakpoints: IDebugger.IBreakpoint[]) {
     return breakpoints.map(breakpoint => {
       return {
         line: breakpoint.line

--- a/src/service.ts
+++ b/src/service.ts
@@ -91,10 +91,10 @@ export class DebugService implements IDebugger {
 
     this._session.eventMessage.connect((_, event) => {
       if (event.event === 'stopped') {
-        this.model.stoppedThreads.add(event.body.threadId);
+        this._model.stoppedThreads.add(event.body.threadId);
         void this.getAllFrames();
       } else if (event.event === 'continued') {
-        this.model.stoppedThreads.delete(event.body.threadId);
+        this._model.stoppedThreads.delete(event.body.threadId);
         this.clearModel();
         this.clearSignals();
       }
@@ -106,7 +106,7 @@ export class DebugService implements IDebugger {
   /**
    * Returns the debugger model.
    */
-  get model(): Debugger.Model {
+  get model(): IDebugger.IModel {
     return this._model;
   }
 
@@ -114,8 +114,8 @@ export class DebugService implements IDebugger {
    * Sets the debugger model to the given parameter.
    * @param model - The new debugger model.
    */
-  set model(model: Debugger.Model) {
-    this._model = model;
+  set model(model: IDebugger.IModel) {
+    this._model = model as Debugger.Model;
     this._modelChanged.emit(model);
   }
 
@@ -129,7 +129,7 @@ export class DebugService implements IDebugger {
   /**
    * Signal emitted upon model changed.
    */
-  get modelChanged(): ISignal<IDebugger, Debugger.Model> {
+  get modelChanged(): ISignal<IDebugger, IDebugger.IModel> {
     return this._modelChanged;
   }
 
@@ -187,7 +187,7 @@ export class DebugService implements IDebugger {
   async stop(): Promise<void> {
     await this.session.stop();
     if (this.model) {
-      this.model.stoppedThreads.clear();
+      this._model.stoppedThreads.clear();
     }
   }
 
@@ -196,7 +196,7 @@ export class DebugService implements IDebugger {
    * Precondition: isStarted().
    */
   async restart(): Promise<void> {
-    const breakpoints = this.model.breakpointsModel.breakpoints;
+    const breakpoints = this._model.breakpointsModel.breakpoints;
     await this.stop();
     this.clearModel();
     await this.start();
@@ -268,7 +268,7 @@ export class DebugService implements IDebugger {
       await this.session.sendRequest('continue', {
         threadId: this.currentThread()
       });
-      this.model.stoppedThreads.delete(this.currentThread());
+      this._model.stoppedThreads.delete(this.currentThread());
     } catch (err) {
       console.error('Error:', err.message);
     }
@@ -523,7 +523,7 @@ export class DebugService implements IDebugger {
   private _isDisposed: boolean = false;
   private _session: IDebugger.ISession;
   private _sessionChanged = new Signal<IDebugger, IDebugger.ISession>(this);
-  private _modelChanged = new Signal<IDebugger, Debugger.Model>(this);
+  private _modelChanged = new Signal<IDebugger, IDebugger.IModel>(this);
   private _eventMessage = new Signal<IDebugger, IDebugger.ISession.Event>(this);
   private _model: Debugger.Model;
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -16,7 +16,6 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 // TODO: remove that import when an interface has
 // been created for Model class
 import { Breakpoints } from './breakpoints';
-import { Debugger } from './debugger';
 
 /**
  * An interface describing an application's visual debugger.
@@ -44,7 +43,7 @@ export interface IDebugger extends IDisposable {
   /**
    * The model of the debugger.
    */
-  model: Debugger.Model;
+  model: IDebugger.IModel;
 
   /**
    * Signal emitted upon session changed.
@@ -54,7 +53,7 @@ export interface IDebugger extends IDisposable {
   /**
    * Signal emitted upon model changed.
    */
-  readonly modelChanged: ISignal<IDebugger, Debugger.Model>;
+  readonly modelChanged: ISignal<IDebugger, IDebugger.IModel>;
 
   /**
    * Signal emitted for debug event messages.
@@ -204,6 +203,11 @@ export namespace IDebugger {
       args: IDebugger.ISession.Request[K]
     ): Promise<IDebugger.ISession.Response[K]>;
   }
+
+  /**
+   * The model of a debugger session.
+   */
+  export interface IModel extends IObservableDisposable {}
 
   export namespace ISession {
     /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -13,10 +13,6 @@ import { ISignal } from '@phosphor/signaling';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 
-// TODO: remove that import when an interface has
-// been created for Model class
-import { Breakpoints } from './breakpoints';
-
 /**
  * An interface describing an application's visual debugger.
  */
@@ -127,7 +123,7 @@ export interface IDebugger extends IDisposable {
    */
   updateBreakpoints(
     code: string,
-    breakpoints: Breakpoints.IBreakpoint[]
+    breakpoints: IDebugger.IBreakpoint[]
   ): Promise<void>;
 
   /**
@@ -202,6 +198,13 @@ export namespace IDebugger {
       command: K,
       args: IDebugger.ISession.Request[K]
     ): Promise<IDebugger.ISession.Response[K]>;
+  }
+
+  /**
+   * Single breakpoint in an editor.
+   */
+  export interface IBreakpoint extends DebugProtocol.Breakpoint {
+    active: boolean;
   }
 
   /**

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -4,8 +4,6 @@ import { ClientSession, IClientSession } from '@jupyterlab/apputils';
 
 import { createClientSession } from '@jupyterlab/testutils';
 
-import { Breakpoints } from '../../lib/breakpoints';
-
 import { Debugger } from '../../lib/debugger';
 
 import { DebugService } from '../../lib/service';
@@ -132,7 +130,7 @@ describe('DebugService', () => {
     it('should emit the modelChanged signal when setting the model', () => {
       let modelChangedEvents: Debugger.Model[] = [];
       service.modelChanged.connect((_, newModel) => {
-        modelChangedEvents.push(newModel);
+        modelChangedEvents.push(newModel as Debugger.Model);
       });
       service.model = model;
       expect(modelChangedEvents.length).to.equal(1);
@@ -150,7 +148,7 @@ describe('DebugService', () => {
       'print(i, j)'
     ].join('\n');
 
-    let breakpoints: Breakpoints.IBreakpoint[];
+    let breakpoints: IDebugger.IBreakpoint[];
     let sourceId: string;
 
     beforeEach(async () => {
@@ -183,7 +181,7 @@ describe('DebugService', () => {
     describe('#restoreState', () => {
       it('should restore the breakpoints', async () => {
         model.breakpointsModel.restoreBreakpoints(
-          new Map<string, Breakpoints.IBreakpoint[]>()
+          new Map<string, IDebugger.IBreakpoint[]>()
         );
         const bpList1 = model.breakpointsModel.getBreakpoints(sourceId);
         expect(bpList1.length).to.equal(0);
@@ -197,7 +195,7 @@ describe('DebugService', () => {
       it('should restart the debugger and send the breakpoints again', async () => {
         await service.restart();
         model.breakpointsModel.restoreBreakpoints(
-          new Map<string, Breakpoints.IBreakpoint[]>()
+          new Map<string, IDebugger.IBreakpoint[]>()
         );
         await service.restoreState(true);
         const bpList = model.breakpointsModel.getBreakpoints(sourceId);


### PR DESCRIPTION
Fixes #218 
The interface `IModel` does not expose anything for now, to limit the constraints on the API if this get integrated in JupyterLab 2.0.