### PR TITLE
Upgrade to TypeScript 3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,14 +73,14 @@
     "jest": "^24.8.0",
     "jest-junit": "^6.3.0",
     "lint-staged": "^9.2.1",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "rimraf": "~2.6.2",
     "ts-jest": "^24",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
     "typedoc": "^0.15.0",
-    "typescript": "~3.5.1"
+    "typescript": "~3.7.2"
   },
   "husky": {
     "hooks": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,14 +183,12 @@ const files: JupyterFrontEndPlugin<void> = {
         if (!tracker || !tracker.currentWidget) {
           return;
         }
-        if (tracker.currentWidget) {
-          const idKernel = debug.session.client.kernel.id;
-          void Kernel.findById(idKernel).catch(() => {
-            if (_model) {
-              Kernel.connectTo(_model);
-            }
-          });
-        }
+        const idKernel = debug.session.client.kernel.id;
+        void Kernel.findById(idKernel).catch(() => {
+          if (_model) {
+            Kernel.connectTo(_model);
+          }
+        });
       }
     });
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -44,8 +44,7 @@ export class DebugService implements IDebugger {
    * Whether debugging is enabled for the current session.
    */
   get isDebuggingEnabled(): boolean {
-    const kernelInfo = this._session.kernelInfo;
-    return (kernelInfo && kernelInfo.debugger) || false;
+    return this._session.kernelInfo?.debugger ?? false;
   }
 
   /**
@@ -160,14 +159,14 @@ export class DebugService implements IDebugger {
    * Whether the current debugger is started.
    */
   isStarted(): boolean {
-    return this._session !== null && this._session.isStarted;
+    return this._session?.isStarted ?? false;
   }
 
   /**
    * Whether there exists a thread in stopped state.
    */
   hasStoppedThreads(): boolean {
-    return this._model && this._model.stoppedThreads.size !== 0;
+    return this._model?.stoppedThreads.size !== 0 ?? false;
   }
 
   /**


### PR DESCRIPTION
Fixes #210. 

@JohanMabille @KsavinN @afshin if you use VS Code you might need to switch to the version with:

![image](https://user-images.githubusercontent.com/591645/69526189-ef5c2e80-0f69-11ea-921d-7c7c3eeeab03.png)

![image](https://user-images.githubusercontent.com/591645/69526144-d6537d80-0f69-11ea-8c0e-a349a411d8ab.png)

### Changes

- Upgrade to TypeScript 3.7
- Update some parts to use [optional chaining](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#optional-chaining) and [nullish coalescing](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#nullish-coalescing)