### PR TITLE
Add "Change Mode" to the sidebar context menu

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -263,6 +263,11 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
     });
 
     app.contextMenu.addItem({
+      command: CommandIDs.changeMode,
+      selector: '.jp-DebuggerSidebar'
+    });
+
+    app.contextMenu.addItem({
       command: CommandIDs.closeDebugger,
       selector: '.jp-DebuggerSidebar'
     });


### PR DESCRIPTION
Fixes #178.

Simple fix to make it easier to change modes without having to use the palette.

We might want to add a real button later on, or something that make it easier to discover.

![image](https://user-images.githubusercontent.com/591645/69533033-5a603200-0f77-11ea-8448-9a1877781d42.png)
