### PR TITLE
Add support for debugging files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@jupyterlab/codeeditor": "^1.1.0",
     "@jupyterlab/console": "^1.1.0",
     "@jupyterlab/coreutils": "^3.1.0",
+    "@jupyterlab/docregistry": "^1.1.0",
     "@jupyterlab/fileeditor": "^1.1.0",
     "@jupyterlab/launcher": "^1.1.0",
     "@jupyterlab/notebook": "^1.1.0",

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -192,7 +192,7 @@ export class EditorHandler implements IDisposable {
   private getBreakpoints(): IDebugger.IBreakpoint[] {
     const code = this._editor.model.value.text;
     return this._debuggerModel.breakpointsModel.getBreakpoints(
-      this._debuggerService.getCellId(code)
+      this._debuggerService.getCodeId(code)
     );
   }
 

--- a/src/handlers/file.ts
+++ b/src/handlers/file.ts
@@ -56,8 +56,8 @@ export class FileHandler implements IDisposable {
     }
 
     const code = editor.model.value.text;
-    const cellId = this.debuggerService.getCodeId(code);
-    if (frame.source.path !== cellId) {
+    const codeId = this.debuggerService.getCodeId(code);
+    if (frame.source.path !== codeId) {
       return;
     }
     // request drawing the line after the editor has been cleared above

--- a/src/handlers/file.ts
+++ b/src/handlers/file.ts
@@ -56,7 +56,7 @@ export class FileHandler implements IDisposable {
     }
 
     const code = editor.model.value.text;
-    const cellId = this.debuggerService.getCellId(code);
+    const cellId = this.debuggerService.getCodeId(code);
     if (frame.source.path !== cellId) {
       return;
     }

--- a/src/handlers/file.ts
+++ b/src/handlers/file.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { FileEditor } from '@jupyterlab/fileeditor';
+
+import { IDisposable } from '@phosphor/disposable';
+
+import { Signal } from '@phosphor/signaling';
+
+import { EditorHandler } from '../handlers/editor';
+
+import { Debugger } from '../debugger';
+
+import { IDebugger } from '../tokens';
+
+export class FileHandler implements IDisposable {
+  constructor(options: DebuggerFileHandler.IOptions) {
+    this.debuggerModel = options.debuggerService.model as Debugger.Model;
+    this.debuggerService = options.debuggerService;
+    this.fileEditor = options.widget;
+
+    this.editorHandler = new EditorHandler({
+      debuggerModel: this.debuggerModel,
+      debuggerService: this.debuggerService,
+      editor: this.fileEditor.editor
+    });
+  }
+
+  isDisposed: boolean;
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+    this.editorHandler.dispose();
+    Signal.clearData(this);
+  }
+
+  private fileEditor: FileEditor;
+  private debuggerModel: Debugger.Model;
+  private debuggerService: IDebugger;
+  private editorHandler: EditorHandler;
+}
+
+export namespace DebuggerFileHandler {
+  export interface IOptions {
+    debuggerService: IDebugger;
+    widget: FileEditor;
+  }
+}

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -84,8 +84,8 @@ export class NotebookHandler implements IDisposable {
     cells.forEach((cell, i) => {
       // check the event is for the correct cell
       const code = cell.model.value.text;
-      const cellId = this.debuggerService.getCodeId(code);
-      if (frame.source.path !== cellId) {
+      const codeId = this.debuggerService.getCodeId(code);
+      if (frame.source.path !== codeId) {
         return;
       }
       this.notebookPanel.content.activeCellIndex = i;

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -84,7 +84,7 @@ export class NotebookHandler implements IDisposable {
     cells.forEach((cell, i) => {
       // check the event is for the correct cell
       const code = cell.model.value.text;
-      const cellId = this.debuggerService.getCellId(code);
+      const cellId = this.debuggerService.getCodeId(code);
       if (frame.source.path !== cellId) {
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ const files: JupyterFrontEndPlugin<void> = {
       [id: string]: Session.ISession;
     } = {};
 
-    labShell.currentChanged.connect((_, update) => {
+    labShell.currentChanged.connect(async (_, update) => {
       const widget = update.newValue;
       if (!(widget instanceof DocumentWidget)) {
         return;
@@ -181,7 +181,8 @@ const files: JupyterFrontEndPlugin<void> = {
       }
 
       const sessions = app.serviceManager.sessions;
-      void sessions.findByPath(widget.context.path).then(async model => {
+      try {
+        const model = await sessions.findByPath(widget.context.path);
         let session = activeSessions[model.id];
         if (!session) {
           // Use `connectTo` only if the session does not exist.
@@ -193,7 +194,9 @@ const files: JupyterFrontEndPlugin<void> = {
         }
         await setDebugSession(app, debug, session);
         handler.update(debug, null, content);
-      });
+      } catch {
+        return;
+      }
     });
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,10 +180,8 @@ const files: JupyterFrontEndPlugin<void> = {
         return;
       }
 
-      //  Finding if the file is backed by a kernel or attach it to one.
       const sessions = app.serviceManager.sessions;
       void sessions.findByPath(widget.context.path).then(async model => {
-        _model = model;
         const session = sessions.connectTo(model);
         await setDebugSession(app, debug, session);
         handler.update(debug, null, content);

--- a/src/service.ts
+++ b/src/service.ts
@@ -151,7 +151,7 @@ export class DebugService implements IDebugger {
   /**
    * Computes an id based on the given code.
    */
-  getCellId(code: string): string {
+  getCodeId(code: string): string {
     return this._tmpFilePrefix + this._hashMethod(code) + this._tmpFileSuffix;
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -3,7 +3,7 @@
 
 import { IClientSession } from '@jupyterlab/apputils';
 
-import { KernelMessage } from '@jupyterlab/services';
+import { KernelMessage, Session } from '@jupyterlab/services';
 
 import { PromiseDelegate } from '@phosphor/coreutils';
 
@@ -41,7 +41,7 @@ export class DebugSession implements IDebugger.ISession {
   /**
    * Returns the API client session to connect to a debugger.
    */
-  get client(): IClientSession {
+  get client(): IClientSession | Session.ISession {
     return this._client;
   }
 
@@ -51,7 +51,7 @@ export class DebugSession implements IDebugger.ISession {
    *
    * @param client - The new API client session.
    */
-  set client(client: IClientSession | null) {
+  set client(client: IClientSession | Session.ISession | null) {
     if (this._client === client) {
       return;
     }
@@ -141,7 +141,7 @@ export class DebugSession implements IDebugger.ISession {
    * Restore the state of a debug session.
    */
   async restoreState(): Promise<IDebugger.ISession.Response['debugInfo']> {
-    await this.client.ready;
+    await this.client.kernel.ready;
     const message = await this.sendRequest('debugInfo', {});
     this._isStarted = message.body.isStarted;
     return message;
@@ -171,7 +171,7 @@ export class DebugSession implements IDebugger.ISession {
    * @param message - the event message.
    */
   private _handleEvent(
-    sender: IClientSession,
+    sender: IClientSession | Session.ISession,
     message: KernelMessage.IIOPubMessage
   ): void {
     const msgType = message.header.msg_type;
@@ -204,7 +204,7 @@ export class DebugSession implements IDebugger.ISession {
     return reply.promise;
   }
 
-  private _client: IClientSession;
+  private _client: IClientSession | Session.ISession;
   private _disposed = new Signal<this, void>(this);
   private _isDisposed: boolean = false;
   private _isStarted: boolean = false;
@@ -223,6 +223,6 @@ export namespace DebugSession {
     /**
      * The client session used by the debug session.
      */
-    client: IClientSession;
+    client: IClientSession | Session.ISession;
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IClientSession } from '@jupyterlab/apputils';
+import { ClientSession, IClientSession } from '@jupyterlab/apputils';
 
 import { KernelMessage, Session } from '@jupyterlab/services';
 
@@ -141,7 +141,11 @@ export class DebugSession implements IDebugger.ISession {
    * Restore the state of a debug session.
    */
   async restoreState(): Promise<IDebugger.ISession.Response['debugInfo']> {
-    await this.client.kernel.ready;
+    if (this.client instanceof ClientSession) {
+      await this.client.ready;
+    } else {
+      await this.client.kernel.ready;
+    }
     const message = await this.sendRequest('debugInfo', {});
     this._isStarted = message.body.isStarted;
     return message;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -59,7 +59,7 @@ export interface IDebugger extends IDisposable {
   /**
    * Computes an id based on the given code.
    */
-  getCellId(code: string): string;
+  getCodeId(code: string): string;
 
   /**
    * Whether the current debugger is started.

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -156,7 +156,7 @@ describe('DebugService', () => {
       service.model = model;
       await service.restoreState(true);
       const breakpointLines: number[] = [3, 5];
-      sourceId = service.getCellId(code);
+      sourceId = service.getCodeId(code);
       breakpoints = breakpointLines.map((l: number, index: number) => {
         return {
           id: index,


### PR DESCRIPTION
Fixes #225.

For now this still requires having a console open, and pressing `Shift-Enter` to execute the selected code.

Later on we will want to add a play or debug button to debug the file. 

### Changes

- [x] The Debug session can take a `IClientSession` or `Session.ISession`
- [x] Add `FileHandler` to handler `FileEditor` widgets (reusing the `EditorHandler`)
- [x] Show line highlighting in the `FileEditor` editor
- [x] Rename `getCellId` to `getCodeId`
- [x] Handle restore

![debug-files2](https://user-images.githubusercontent.com/591645/69621004-91e5e180-103e-11ea-805d-29de9977bce7.gif)