### PR TITLE
Add plugin to track notebooks, consoles and editors

### DIFF
--- a/src/handlers/file.ts
+++ b/src/handlers/file.ts
@@ -9,8 +9,6 @@ import { Signal } from '@phosphor/signaling';
 
 import { EditorHandler } from '../handlers/editor';
 
-import { Callstack } from '../callstack';
-
 import { Debugger } from '../debugger';
 
 import { IDebugger } from '../tokens';
@@ -26,11 +24,6 @@ export class FileHandler implements IDisposable {
       debuggerService: this.debuggerService,
       editor: this.fileEditor.editor
     });
-
-    this.debuggerModel.callstackModel.currentFrameChanged.connect(
-      this.onCurrentFrameChanged,
-      this
-    );
   }
 
   isDisposed: boolean;
@@ -44,27 +37,6 @@ export class FileHandler implements IDisposable {
     Signal.clearData(this);
   }
 
-  private onCurrentFrameChanged(
-    callstackModel: Callstack.Model,
-    frame: Callstack.IFrame
-  ) {
-    const editor = this.fileEditor.editor;
-    EditorHandler.clearHighlight(editor);
-
-    if (!frame) {
-      return;
-    }
-
-    const code = editor.model.value.text;
-    const codeId = this.debuggerService.getCodeId(code);
-    if (frame.source.path !== codeId) {
-      return;
-    }
-    // request drawing the line after the editor has been cleared above
-    requestAnimationFrame(() => {
-      EditorHandler.showCurrentLine(editor, frame);
-    });
-  }
   private fileEditor: FileEditor;
   private debuggerModel: Debugger.Model;
   private debuggerService: IDebugger;

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -11,8 +11,6 @@ import { IDisposable } from '@phosphor/disposable';
 
 import { Signal } from '@phosphor/signaling';
 
-import { Callstack } from '../callstack';
-
 import { Debugger } from '../debugger';
 
 import { EditorHandler } from './editor';
@@ -29,11 +27,6 @@ export class NotebookHandler implements IDisposable {
     const notebook = this.notebookPanel.content;
     notebook.widgets.forEach(cell => this.addEditorHandler(cell));
     notebook.activeCellChanged.connect(this.onActiveCellChanged, this);
-
-    this.debuggerModel.callstackModel.currentFrameChanged.connect(
-      this.onCurrentFrameChanged,
-      this
-    );
   }
 
   isDisposed: boolean;
@@ -74,32 +67,6 @@ export class NotebookHandler implements IDisposable {
       return;
     }
     this.addEditorHandler(cell);
-  }
-
-  private onCurrentFrameChanged(
-    callstackModel: Callstack.Model,
-    frame: Callstack.IFrame
-  ) {
-    const cells = this.notebookPanel.content.widgets;
-    cells.forEach(cell => EditorHandler.clearHighlight(cell.editor));
-
-    if (!frame) {
-      return;
-    }
-
-    cells.forEach((cell, i) => {
-      // check the event is for the correct cell
-      const code = cell.model.value.text;
-      const codeId = this.debuggerService.getCodeId(code);
-      if (frame.source.path !== codeId) {
-        return;
-      }
-      this.notebookPanel.content.activeCellIndex = i;
-      // request drawing the line after the editor has been cleared above
-      requestAnimationFrame(() => {
-        EditorHandler.showCurrentLine(cell.editor, frame);
-      });
-    });
   }
 
   private debuggerModel: Debugger.Model;

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -16,7 +16,7 @@ import { Debugger } from '../debugger';
 
 import { IDebugger } from '../tokens';
 
-export class WidgetHandler implements IDisposable {
+export class TrackerHandler implements IDisposable {
   constructor(options: DebuggerWidgetHandler.IOptions) {
     this.debuggerService = options.debuggerService;
     this.notebookTracker = options.notebookTracker;

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -10,10 +10,11 @@ import { Signal } from '@phosphor/signaling';
 
 import { Callstack } from '../callstack';
 
+import { EditorHandler } from './editor';
+
 import { Debugger } from '../debugger';
 
 import { IDebugger } from '../tokens';
-import { EditorHandler } from './editor';
 
 export class WidgetHandler implements IDisposable {
   constructor(options: DebuggerWidgetHandler.IOptions) {
@@ -64,6 +65,8 @@ export class WidgetHandler implements IDisposable {
       }
 
       const cells = notebookPanel.content.widgets;
+      // TODO: we might reconsider clearing all cells, for example
+      // there could be more than 1 stopped thread, and in different cells
       cells.forEach(cell => EditorHandler.clearHighlight(cell.editor));
 
       if (!frame) {

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -48,12 +48,12 @@ export class TrackerHandler implements IDisposable {
     frame: Callstack.IFrame
   ) {
     const debugSessionPath = this.debuggerService.session.client.path;
-    this.handleNotebooks(debugSessionPath, frame);
-    this.handleConsoles(debugSessionPath, frame);
-    this.handleEditors(debugSessionPath, frame);
+    this.findInNotebooks(debugSessionPath, frame);
+    this.findInConsoles(debugSessionPath, frame);
+    this.findInEditors(debugSessionPath, frame);
   }
 
-  protected handleNotebooks(debugSessionPath: string, frame: Callstack.IFrame) {
+  protected findInNotebooks(debugSessionPath: string, frame: Callstack.IFrame) {
     if (!this.notebookTracker) {
       return;
     }
@@ -88,7 +88,7 @@ export class TrackerHandler implements IDisposable {
     });
   }
 
-  protected handleConsoles(debugSessionPath: string, frame: Callstack.IFrame) {
+  protected findInConsoles(debugSessionPath: string, frame: Callstack.IFrame) {
     if (!this.consoleTracker) {
       return;
     }
@@ -99,20 +99,23 @@ export class TrackerHandler implements IDisposable {
         return;
       }
 
-      const code = consoleWidget?.console.promptCell.model.value.text ?? null;
-      if (!code) {
+      const editor = consoleWidget?.console.promptCell?.editor ?? null;
+      if (!editor) {
         return;
       }
 
+      const code = editor.model.value.text;
       const codeId = this.debuggerService.getCodeId(code);
       if (frame.source.path !== codeId) {
         return;
       }
-      // TODO
+      requestAnimationFrame(() => {
+        EditorHandler.showCurrentLine(editor, frame);
+      });
     });
   }
 
-  protected handleEditors(debugSessionPath: string, frame: Callstack.IFrame) {
+  protected findInEditors(debugSessionPath: string, frame: Callstack.IFrame) {
     if (!this.editorTracker) {
       return;
     }

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -89,7 +89,7 @@ export class TrackerHandler implements IDisposable {
   }
 
   protected findInConsoles(debugSessionPath: string, frame: Callstack.IFrame) {
-    if (!this.consoleTracker) {
+    if (!this.consoleTracker || !frame) {
       return;
     }
     this.consoleTracker.forEach(consoleWidget => {

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -16,8 +16,14 @@ import { Debugger } from '../debugger';
 
 import { IDebugger } from '../tokens';
 
+/**
+ * A class which handles notebook, console and editor trackers.
+ */
 export class TrackerHandler implements IDisposable {
-  constructor(options: DebuggerWidgetHandler.IOptions) {
+  /**
+   * Constructs a new TrackerHandler.
+   */
+  constructor(options: DebuggerTrackerHandler.IOptions) {
     this.debuggerService = options.debuggerService;
     this.notebookTracker = options.notebookTracker;
     this.consoleTracker = options.consoleTracker;
@@ -153,7 +159,13 @@ export class TrackerHandler implements IDisposable {
   private editorTracker: IEditorTracker | null;
 }
 
-export namespace DebuggerWidgetHandler {
+/**
+ * A namespace for DebuggerTrackerHandler statics.
+ */
+export namespace DebuggerTrackerHandler {
+  /**
+   * The options used to initialize a DebuggerTrackerHandler object.
+   */
   export interface IOptions {
     debuggerService: IDebugger;
     notebookTracker?: INotebookTracker;

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -1,0 +1,133 @@
+import { IEditorTracker } from '@jupyterlab/fileeditor';
+
+import { INotebookTracker } from '@jupyterlab/notebook';
+
+import { IConsoleTracker } from '@jupyterlab/console';
+
+import { IDisposable } from '@phosphor/disposable';
+
+import { Signal } from '@phosphor/signaling';
+
+import { Callstack } from '../callstack';
+
+import { Debugger } from '../debugger';
+
+import { IDebugger } from '../tokens';
+import { EditorHandler } from './editor';
+
+export class WidgetHandler implements IDisposable {
+  constructor(options: DebuggerWidgetHandler.IOptions) {
+    this.debuggerService = options.debuggerService;
+    this.notebookTracker = options.notebookTracker;
+    this.consoleTracker = options.consoleTracker;
+    this.editorTracker = options.editorTracker;
+
+    this.debuggerService.modelChanged.connect(() => {
+      const debuggerModel = this.debuggerService.model as Debugger.Model;
+
+      debuggerModel.callstackModel.currentFrameChanged.connect(
+        this.onCurrentFrameChanged,
+        this
+      );
+    });
+  }
+
+  isDisposed: boolean;
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+    Signal.clearData(this);
+  }
+
+  protected onCurrentFrameChanged(
+    callstackModel: Callstack.Model,
+    frame: Callstack.IFrame
+  ) {
+    const debugSessionPath = this.debuggerService.session.client.path;
+    this.handleNotebooks(debugSessionPath, frame);
+    this.handleConsoles(debugSessionPath, frame);
+    this.handleEditors(debugSessionPath, frame);
+  }
+
+  protected handleNotebooks(debugSessionPath: string, frame: Callstack.IFrame) {
+    if (!this.notebookTracker) {
+      return;
+    }
+    this.notebookTracker.forEach(notebookPanel => {
+      const session = notebookPanel.session;
+
+      if (session.path !== debugSessionPath) {
+        return;
+      }
+
+      const cells = notebookPanel.content.widgets;
+      cells.forEach(cell => EditorHandler.clearHighlight(cell.editor));
+
+      if (!frame) {
+        return;
+      }
+
+      cells.forEach((cell, i) => {
+        // check the event is for the correct cell
+        const code = cell.model.value.text;
+        const cellId = this.debuggerService.getCodeId(code);
+        if (frame.source.path !== cellId) {
+          return;
+        }
+        notebookPanel.content.activeCellIndex = i;
+        // request drawing the line after the editor has been cleared above
+        requestAnimationFrame(() => {
+          EditorHandler.showCurrentLine(cell.editor, frame);
+        });
+      });
+    });
+  }
+
+  protected handleConsoles(debugSessionPath: string, frame: Callstack.IFrame) {
+    if (!this.consoleTracker) {
+      return;
+    }
+    this.consoleTracker.forEach(consoleWidget => {
+      const session = consoleWidget.session;
+
+      if (session.path !== debugSessionPath) {
+        return;
+      }
+
+      const code = consoleWidget?.console.promptCell.model.value.text ?? null;
+      if (!code) {
+        return;
+      }
+
+      const codeId = this.debuggerService.getCodeId(code);
+      if (frame.source.path !== codeId) {
+        return;
+      }
+      // TODO
+    });
+  }
+
+  protected handleEditors(debugSessionPath: string, frame: Callstack.IFrame) {
+    if (!this.editorTracker) {
+      return;
+    }
+    // TODO
+  }
+
+  private debuggerService: IDebugger;
+  private notebookTracker: INotebookTracker | null;
+  private consoleTracker: IConsoleTracker | null;
+  private editorTracker: IEditorTracker | null;
+}
+
+export namespace DebuggerWidgetHandler {
+  export interface IOptions {
+    debuggerService: IDebugger;
+    notebookTracker?: INotebookTracker;
+    consoleTracker?: IConsoleTracker;
+    editorTracker?: IEditorTracker;
+  }
+}

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -78,7 +78,6 @@ export class WidgetHandler implements IDisposable {
           return;
         }
         notebookPanel.content.activeCellIndex = i;
-        // request drawing the line after the editor has been cleared above
         requestAnimationFrame(() => {
           EditorHandler.showCurrentLine(cell.editor, frame);
         });
@@ -114,7 +113,32 @@ export class WidgetHandler implements IDisposable {
     if (!this.editorTracker) {
       return;
     }
-    // TODO
+    this.editorTracker.forEach(doc => {
+      const fileEditor = doc.content;
+      if (debugSessionPath !== fileEditor.context.path) {
+        return;
+      }
+
+      const editor = fileEditor.editor;
+      if (!editor) {
+        return;
+      }
+
+      EditorHandler.clearHighlight(editor);
+
+      if (!frame) {
+        return;
+      }
+
+      const code = editor.model.value.text;
+      const codeId = this.debuggerService.getCodeId(code);
+      if (frame.source.path !== codeId) {
+        return;
+      }
+      requestAnimationFrame(() => {
+        EditorHandler.showCurrentLine(editor, frame);
+      });
+    });
   }
 
   private debuggerService: IDebugger;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import { FileHandler } from './handlers/file';
 
 import { NotebookHandler } from './handlers/notebook';
 
-import { WidgetHandler } from './handlers/tracker';
+import { TrackerHandler } from './handlers/tracker';
 
 import { DebugService } from './service';
 
@@ -239,7 +239,7 @@ const tracker: JupyterFrontEndPlugin<void> = {
     consoleTracker: IConsoleTracker,
     editorTracker: IEditorTracker
   ) => {
-    new WidgetHandler({
+    new TrackerHandler({
       debuggerService: debug,
       notebookTracker,
       consoleTracker,

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ import { FileHandler } from './handlers/file';
 
 import { NotebookHandler } from './handlers/notebook';
 
+import { WidgetHandler } from './handlers/tracker';
+
 import { DebugService } from './service';
 
 import { DebugSession } from './session';
@@ -95,10 +97,10 @@ class DebuggerHandler<
     this.builder = builder;
   }
 
-  update<
-    T extends IConsoleTracker | INotebookTracker | null,
-    W extends ConsolePanel | NotebookPanel | FileEditor
-  >(debug: IDebugger, tracker: T, widget: W): void {
+  update<W extends ConsolePanel | NotebookPanel | FileEditor>(
+    debug: IDebugger,
+    widget: W
+  ): void {
     if (!debug.model || this.handlers[widget.id] || !debug.isDebuggingEnabled) {
       return;
     }
@@ -136,13 +138,8 @@ class DebuggerHandler<
 const consoles: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/debugger:consoles',
   autoStart: true,
-  requires: [IDebugger, IConsoleTracker, ILabShell],
-  activate: (
-    app: JupyterFrontEnd,
-    debug: IDebugger,
-    tracker: IConsoleTracker,
-    labShell: ILabShell
-  ) => {
+  requires: [IDebugger, ILabShell],
+  activate: (app: JupyterFrontEnd, debug: IDebugger, labShell: ILabShell) => {
     const handler = new DebuggerHandler<ConsoleHandler>(ConsoleHandler);
 
     labShell.currentChanged.connect(async (_, update) => {
@@ -151,7 +148,7 @@ const consoles: JupyterFrontEndPlugin<void> = {
         return;
       }
       await setDebugSession(app, debug, widget.session);
-      handler.update(debug, tracker, widget);
+      handler.update(debug, widget);
     });
   }
 };
@@ -198,7 +195,7 @@ const files: JupyterFrontEndPlugin<void> = {
           activeSessions[model.id] = session;
         }
         await setDebugSession(app, debug, session);
-        handler.update(debug, null, content);
+        handler.update(debug, content);
       } catch {
         return;
       }
@@ -212,13 +209,8 @@ const files: JupyterFrontEndPlugin<void> = {
 const notebooks: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/debugger:notebooks',
   autoStart: true,
-  requires: [IDebugger, INotebookTracker, ILabShell],
-  activate: (
-    app: JupyterFrontEnd,
-    debug: IDebugger,
-    tracker: INotebookTracker,
-    labShell: ILabShell
-  ) => {
+  requires: [IDebugger, ILabShell],
+  activate: (app: JupyterFrontEnd, debug: IDebugger, labShell: ILabShell) => {
     const handler = new DebuggerHandler<NotebookHandler>(NotebookHandler);
 
     labShell.activeChanged.connect(async (_, update) => {
@@ -227,7 +219,31 @@ const notebooks: JupyterFrontEndPlugin<void> = {
         return;
       }
       await setDebugSession(app, debug, widget.session);
-      handler.update(debug, tracker, widget);
+      handler.update(debug, widget);
+    });
+  }
+};
+
+/**
+ * A plugin that tracks notebook, console and file editors used for debugging.
+ */
+const tracker: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/debugger:tracker',
+  autoStart: true,
+  requires: [IDebugger],
+  optional: [INotebookTracker, IConsoleTracker, IEditorTracker],
+  activate: (
+    app: JupyterFrontEnd,
+    debug: IDebugger,
+    notebookTracker: INotebookTracker,
+    consoleTracker: IConsoleTracker,
+    editorTracker: IEditorTracker
+  ) => {
+    new WidgetHandler({
+      debuggerService: debug,
+      notebookTracker,
+      consoleTracker,
+      editorTracker
     });
   }
 };
@@ -496,6 +512,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   consoles,
   files,
   notebooks,
+  tracker,
   main
 ];
 


### PR DESCRIPTION
~This PR builds on top of #231 should be rebased when #231 is merged.~ [done]

This change lays the foundations for #176, #212 and #224.

This idea is have a plugin that depends on `INotebookTracker`, `IConsoleTracker` and `IEditorTracker` (all optional), that will be used to find the `CodeEditor.IEditor` from where an event originated. An event could be:

- a `stopped` event that contains the source path
- a click on a breakpoint (#224) (which also contains the source path)

The `TrackerHandler` iterates through all the widgets of the trackers to try to find a matching hash. When there is no match, this is where we could extend the logic to open files in the main area (#212) or to the read-only code editor view.