### PR TITLE
Allow setting breakpoints in out-of-focus cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@jupyterlab/docregistry": "^1.1.0",
     "@jupyterlab/fileeditor": "^1.1.0",
     "@jupyterlab/launcher": "^1.1.0",
+    "@jupyterlab/observables": "^2.4.0",
     "@jupyterlab/notebook": "^1.1.0",
     "@jupyterlab/services": "^4.1.0",
     "@phosphor/algorithm": "^1.2.0",

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -140,7 +140,6 @@ export class EditorHandler implements IDisposable {
       return;
     }
 
-    editor.focus();
     const isRemoveGutter = !!info.gutterMarkers;
     let breakpoints: IDebugger.IBreakpoint[] = this.getBreakpoints();
     if (isRemoveGutter) {

--- a/style/breakpoints.css
+++ b/style/breakpoints.css
@@ -40,11 +40,8 @@
 }
 
 .jp-Notebook
-  .jp-mod-editMode
   .jp-CodeCell.jp-mod-selected
   .CodeMirror-gutter-wrapper:hover::after,
-.jp-Editor.jp-mod-focused
-  .CodeMirror:not(.jp-mod-readOnly)
-  .CodeMirror-gutter-wrapper:hover::after {
+.jp-Editor .CodeMirror-gutter-wrapper:hover::after {
   opacity: 0.5;
 }


### PR DESCRIPTION
Fixes #238 

Allowing setting breakpoints in other cells even when they don't have the focus does feel more natural.

Also all the gutters initialized at the same when the notebook handler is created, which also feels more intuitive. 

![breakpoint-out-of-focus-cells](https://user-images.githubusercontent.com/591645/69952575-c7377700-14f7-11ea-812b-992c4f975459.gif)
