### PR TITLE
Add support for breakpoints in modules and files

### DIFF
--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -28,6 +28,7 @@ const EDITOR_CHANGED_TIMEOUT = 1000;
 export class EditorHandler implements IDisposable {
   constructor(options: EditorHandler.IOptions) {
     this._id = options.debuggerService.session.client.path;
+    this._path = options.path;
     this._debuggerService = options.debuggerService;
     this.onModelChanged();
     this._debuggerService.modelChanged.connect(() => this.onModelChanged());
@@ -98,7 +99,8 @@ export class EditorHandler implements IDisposable {
 
     void this._debuggerService.updateBreakpoints(
       this._editor.model.value.text,
-      breakpoints
+      breakpoints,
+      this._path
     );
   }
 
@@ -144,7 +146,7 @@ export class EditorHandler implements IDisposable {
     } else {
       breakpoints.push(
         Private.createBreakpoint(
-          this._debuggerService.session.client.name,
+          this._path ?? this._debuggerService.session.client.name,
           this.getEditorId(),
           info.line + 1
         )
@@ -153,7 +155,8 @@ export class EditorHandler implements IDisposable {
 
     void this._debuggerService.updateBreakpoints(
       this._editor.model.value.text,
-      breakpoints
+      breakpoints,
+      this._path
     );
   };
 
@@ -188,7 +191,7 @@ export class EditorHandler implements IDisposable {
   private getBreakpoints(): IDebugger.IBreakpoint[] {
     const code = this._editor.model.value.text;
     return this._debuggerModel.breakpointsModel.getBreakpoints(
-      this._debuggerService.getCodeId(code)
+      this._path ?? this._debuggerService.getCodeId(code)
     );
   }
 
@@ -197,6 +200,7 @@ export class EditorHandler implements IDisposable {
   private breakpointsModel: Breakpoints.Model;
   private _debuggerService: IDebugger;
   private _id: string;
+  private _path: string;
   private _editorMonitor: ActivityMonitor<
     IObservableString,
     IObservableString.IChangedArgs
@@ -207,6 +211,7 @@ export namespace EditorHandler {
   export interface IOptions {
     debuggerService: IDebugger;
     editor: CodeEditor.IEditor;
+    path?: string;
   }
 
   /**

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -138,7 +138,8 @@ export class TrackerHandler implements IDisposable {
     const editor = editorWrapper.editor;
     const editorHandler = new EditorHandler({
       debuggerService: this.debuggerService,
-      editor
+      editor,
+      path
     });
     const widget = new MainAreaWidget<CodeEditorWrapper>({
       content: editorWrapper
@@ -264,7 +265,7 @@ export class TrackerHandler implements IDisposable {
 
       const code = editor.model.value.text;
       const codeId = this.debuggerService.getCodeId(code);
-      if (source !== codeId) {
+      if (widget.title.caption !== source && source !== codeId) {
         return;
       }
       editors.push(editor);

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -108,7 +108,8 @@ export class Sources extends Panel {
 
     this.editorHandler = new EditorHandler({
       debuggerService: this.debuggerService,
-      editor: this.editor.editor
+      editor: this.editor.editor,
+      path
     });
 
     this.model.currentSource = {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -111,10 +111,12 @@ export interface IDebugger {
    * Update all breakpoints of a cell at once.
    * @param code - The code in the cell where the breakpoints are set.
    * @param breakpoints - The list of breakpoints to set.
+   * @param path - Optional path to the file where to set the breakpoints.
    */
   updateBreakpoints(
     code: string,
-    breakpoints: IDebugger.IBreakpoint[]
+    breakpoints: IDebugger.IBreakpoint[],
+    path?: string
   ): Promise<void>;
 
   /**


### PR DESCRIPTION
Fixes #243.

Builds on top of #247. For a cleaner diff see commit https://github.com/jupyterlab/debugger/commit/5df41546222067a75428d8b474384aa789183ca6.

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/debugger/local-module-files?urlpath=/lab/tree/examples/index.ipynb)

This lets users set breakpoints in local modules and files. The breakpoints show up with the absolute path to the file in the `Breakpoints` split.

### TODO

- [x] Support optional `path` when setting breakpoints
- [x] Rebase

![local-module-breakpoints](https://user-images.githubusercontent.com/591645/70240774-21417200-176e-11ea-830f-202c66599d9d.gif)
