### PR TITLE
Set session to null on model disposed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,7 @@ class DebuggerHandler<
         return;
       }
       await debug.stop();
+      debug.session = null;
       handlerIds.forEach(id => {
         this.handlers[id].dispose();
       });

--- a/src/service.ts
+++ b/src/service.ts
@@ -88,7 +88,7 @@ export class DebugService implements IDebugger, IDisposable {
     }
     this._session = session;
 
-    this._session.eventMessage.connect((_, event) => {
+    this._session?.eventMessage.connect((_, event) => {
       if (event.event === 'stopped') {
         this._model.stoppedThreads.add(event.body.threadId);
         void this.getAllFrames();


### PR DESCRIPTION
Fixes #230. 

The debug service would keep a reference to the last used session. Instead we can do the same as for the model and set it to `null`.