### PR TITLE
Replace "Environment" by the jp-BugIcon

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -37,7 +37,7 @@ export namespace Debugger {
     constructor(options: Sidebar.IOptions) {
       super();
       this.id = 'jp-debugger-sidebar';
-      this.title.label = 'Environment';
+      this.title.iconClass = 'jp-BugIcon jp-SideBar-tabIcon';
       this.orientation = 'vertical';
 
       this.addClass('jp-DebuggerSidebar');


### PR DESCRIPTION
This was suggested by @tgeorgeux to keep a uniform look for all the tab bar icons.


![image](https://user-images.githubusercontent.com/591645/70317592-5ad1b600-181e-11ea-8958-13b89edb013e.png)

Also this will look less out of place when switching sidebar side:

![image](https://user-images.githubusercontent.com/591645/70317771-b2702180-181e-11ea-8b29-b4f257afffbf.png)