### PR TITLE
Show source path above the read-only preview editor

### DIFF
--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -47,7 +47,7 @@ class BreakpointsHeader extends Widget {
     super({ node: document.createElement('header') });
 
     const layout = new PanelLayout();
-    const span = new Widget({ node: document.createElement('span') });
+    const span = new Widget({ node: document.createElement('h2') });
 
     this.layout = layout;
     span.node.textContent = title;

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -17,9 +17,8 @@ export class Breakpoints extends Panel {
     this.model = options.model;
     this.service = options.service;
     this.addClass('jp-DebuggerBreakpoints');
-    this.title.label = 'Breakpoints';
 
-    const header = new BreakpointsHeader(this.title.label);
+    const header = new BreakpointsHeader();
     this.body = new Body(this.model);
 
     this.addWidget(header);
@@ -43,15 +42,15 @@ export class Breakpoints extends Panel {
 }
 
 class BreakpointsHeader extends Widget {
-  constructor(title: string) {
+  constructor() {
     super({ node: document.createElement('header') });
 
     const layout = new PanelLayout();
-    const span = new Widget({ node: document.createElement('h2') });
+    const title = new Widget({ node: document.createElement('h2') });
 
     this.layout = layout;
-    span.node.textContent = title;
-    layout.addWidget(span);
+    title.node.textContent = 'Breakpoints';
+    layout.addWidget(title);
     layout.addWidget(this.toolbar);
   }
 

--- a/src/callstack/index.ts
+++ b/src/callstack/index.ts
@@ -74,7 +74,7 @@ class CallstackHeader extends Widget {
     super({ node: document.createElement('header') });
 
     const layout = new PanelLayout();
-    const span = new Widget({ node: document.createElement('span') });
+    const span = new Widget({ node: document.createElement('h2') });
 
     this.layout = layout;
     span.node.textContent = title;

--- a/src/callstack/index.ts
+++ b/src/callstack/index.ts
@@ -17,9 +17,8 @@ export class Callstack extends Panel {
 
     this.model = model;
     this.addClass('jp-DebuggerCallstack');
-    this.title.label = 'Callstack';
 
-    const header = new CallstackHeader(this.title.label);
+    const header = new CallstackHeader();
     const body = new Body(this.model);
 
     this.addWidget(header);
@@ -70,15 +69,15 @@ export class Callstack extends Panel {
 }
 
 class CallstackHeader extends Widget {
-  constructor(title: string) {
+  constructor() {
     super({ node: document.createElement('header') });
 
     const layout = new PanelLayout();
-    const span = new Widget({ node: document.createElement('h2') });
+    const title = new Widget({ node: document.createElement('h2') });
 
     this.layout = layout;
-    span.node.textContent = title;
-    layout.addWidget(span);
+    title.node.textContent = 'Callstack';
+    layout.addWidget(title);
     layout.addWidget(this.toolbar);
   }
 

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -15,9 +15,8 @@ export class Variables extends Panel {
 
     this.model = options.model;
     this.addClass('jp-DebuggerVariables');
-    this.title.label = 'Variables';
 
-    this.header = new VariablesHeader(this.title.label);
+    this.header = new VariablesHeader();
     this.body = new Body(this.model);
 
     this.addWidget(this.header);
@@ -40,14 +39,14 @@ export class Variables extends Panel {
 }
 
 class VariablesHeader extends Widget {
-  constructor(title: string) {
+  constructor() {
     super({ node: document.createElement('header') });
     const layout = new PanelLayout();
-    const span = new Widget({ node: document.createElement('h2') });
+    const title = new Widget({ node: document.createElement('h2') });
 
     this.layout = layout;
-    span.node.textContent = title;
-    layout.addWidget(span);
+    title.node.textContent = 'Variables';
+    layout.addWidget(title);
   }
 }
 

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -43,7 +43,7 @@ class VariablesHeader extends Widget {
   constructor(title: string) {
     super({ node: document.createElement('header') });
     const layout = new PanelLayout();
-    const span = new Widget({ node: document.createElement('span') });
+    const span = new Widget({ node: document.createElement('h2') });
 
     this.layout = layout;
     span.node.textContent = title;

--- a/style/sidebar.css
+++ b/style/sidebar.css
@@ -27,7 +27,7 @@
   border-top: none;
 }
 
-.jp-DebuggerSidebar > div > header > span {
+.jp-DebuggerSidebar > div > header > h2 {
   text-transform: uppercase;
   font-weight: 600;
   font-size: var(--jp-ui-font-size0);

--- a/style/sources.css
+++ b/style/sources.css
@@ -6,3 +6,11 @@
 [data-jp-debugger='true'].jp-Editor {
   height: 100%;
 }
+
+.jp-DebuggerSources > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color1);
+}


### PR DESCRIPTION
Fixes #253.

Show the source path as we step into the code, so it's easier to know where the current execution has stopped.

![show-source-path](https://user-images.githubusercontent.com/591645/70419606-0f114d80-1a66-11ea-8082-55f44cda1daf.gif)
