### PR TITLE
Align breakpoint line numbers

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -94,6 +94,7 @@ const BreakpointComponent = ({
     <div
       className={`breakpoint`}
       onClick={() => model.clicked.emit(breakpoint)}
+      title={breakpoint.source.path}
     >
       <span className={'marker'}>●</span>
       <span className={'source'}>{breakpoint.source.path}</span>

--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -95,9 +95,9 @@ const BreakpointComponent = ({
       className={`breakpoint`}
       onClick={() => model.clicked.emit(breakpoint)}
     >
-      <span>
-        {breakpoint.source.path} : {breakpoint.line}
-      </span>
+      <span className={'marker'}>●</span>
+      <span className={'source'}>{breakpoint.source.path}</span>
+      <span>{breakpoint.line}</span>
     </div>
   );
 };

--- a/style/breakpoints.css
+++ b/style/breakpoints.css
@@ -7,19 +7,23 @@
   padding: 10px;
 }
 
-.jp-DebuggerBreakpoints-body .breakpoint span::before {
+.jp-DebuggerBreakpoints-body .breakpoint .marker {
   font-size: 20px;
   padding-right: 5px;
   content: '●';
   color: var(--jp-error-color1);
 }
 
-.jp-DebuggerBreakpoints-body .breakpoint span {
+.jp-DebuggerBreakpoints-body .breakpoint {
   display: flex;
   align-items: center;
 }
 
-.jp-DebuggerBreakpoints-body .breakpoint span:hover {
+.jp-DebuggerBreakpoints-body .breakpoint .source {
+  flex-grow: 1;
+}
+
+.jp-DebuggerBreakpoints-body .breakpoint:hover {
   background: var(--jp-layout-color2);
   cursor: pointer;
 }

--- a/style/breakpoints.css
+++ b/style/breakpoints.css
@@ -21,6 +21,8 @@
 
 .jp-DebuggerBreakpoints-body .breakpoint .source {
   flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .jp-DebuggerBreakpoints-body .breakpoint:hover {


### PR DESCRIPTION
A quick pass on the breakpoints UI to:

- align the line numbers to the right
- handle the overflow for long source path
- add title attribute with the full path

![image](https://user-images.githubusercontent.com/591645/70434226-ebf59680-1a83-11ea-9423-6d9aa2526992.png)