### PR TITLE
Use kernel name as adapterID

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -111,7 +111,7 @@ export class DebugSession implements IDebugger.ISession {
     await this.sendRequest('initialize', {
       clientID: 'jupyterlab',
       clientName: 'JupyterLab',
-      adapterID: 'python',
+      adapterID: this.client.kernel?.name ?? '',
       pathFormat: 'path',
       linesStartAt1: true,
       columnsStartAt1: true,


### PR DESCRIPTION
We can use the kernel name for the `adapterID` field instead of hard-coding it to `python`.