### PR TITLE
Use more succint names for the sub-models

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -38,17 +38,17 @@ export namespace Debugger {
       this.service = service as DebugService;
       this.service.model = this.model;
 
-      this.variables = new Variables({ model: this.model.variablesModel });
+      this.variables = new Variables({ model: this.model.variables });
       this.callstack = new Callstack({
         commands: callstackCommands,
-        model: this.model.callstackModel
+        model: this.model.callstack
       });
       this.breakpoints = new Breakpoints({
         service,
-        model: this.model.breakpointsModel
+        model: this.model.breakpoints
       });
       this.sources = new Sources({
-        model: this.model.sourcesModel,
+        model: this.model.sources,
         service,
         editorServices
       });
@@ -79,18 +79,18 @@ export namespace Debugger {
 
   export class Model implements IDebugger.IModel {
     constructor(options: Debugger.Model.IOptions) {
-      this.breakpointsModel = new Breakpoints.Model();
-      this.callstackModel = new Callstack.Model([]);
-      this.variablesModel = new Variables.Model([]);
-      this.sourcesModel = new Sources.Model({
-        currentFrameChanged: this.callstackModel.currentFrameChanged
+      this.breakpoints = new Breakpoints.Model();
+      this.callstack = new Callstack.Model([]);
+      this.variables = new Variables.Model([]);
+      this.sources = new Sources.Model({
+        currentFrameChanged: this.callstack.currentFrameChanged
       });
     }
 
-    readonly breakpointsModel: Breakpoints.Model;
-    readonly callstackModel: Callstack.Model;
-    readonly variablesModel: Variables.Model;
-    readonly sourcesModel: Sources.Model;
+    readonly breakpoints: Breakpoints.Model;
+    readonly callstack: Callstack.Model;
+    readonly variables: Variables.Model;
+    readonly sources: Sources.Model;
 
     dispose(): void {
       this._isDisposed = true;

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -34,7 +34,7 @@ export namespace Debugger {
 
       const { callstackCommands, editorServices, service } = options;
 
-      this.model = new Debugger.Model({});
+      this.model = new Debugger.Model();
       this.service = service as DebugService;
       this.service.model = this.model;
 
@@ -78,7 +78,7 @@ export namespace Debugger {
   }
 
   export class Model implements IDebugger.IModel {
-    constructor(options: Debugger.Model.IOptions) {
+    constructor() {
       this.breakpoints = new Breakpoints.Model();
       this.callstack = new Callstack.Model([]);
       this.variables = new Variables.Model([]);
@@ -133,9 +133,5 @@ export namespace Debugger {
       callstackCommands: Callstack.ICommands;
       editorServices: IEditorServices;
     }
-  }
-
-  export namespace Model {
-    export interface IOptions {}
   }
 }

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -53,9 +53,9 @@ export class EditorHandler implements IDisposable {
     if (!this._debuggerModel) {
       return;
     }
-    this.breakpointsModel = this._debuggerModel.breakpointsModel;
+    this.breakpointsModel = this._debuggerModel.breakpoints;
 
-    this._debuggerModel.callstackModel.currentFrameChanged.connect(() => {
+    this._debuggerModel.callstack.currentFrameChanged.connect(() => {
       EditorHandler.clearHighlight(this._editor);
     });
 
@@ -190,7 +190,7 @@ export class EditorHandler implements IDisposable {
 
   private getBreakpoints(): IDebugger.IBreakpoint[] {
     const code = this._editor.model.value.text;
-    return this._debuggerModel.breakpointsModel.getBreakpoints(
+    return this._debuggerModel.breakpoints.getBreakpoints(
       this._path ?? this._debuggerService.getCodeId(code)
     );
   }

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -88,26 +88,24 @@ export class TrackerHandler implements IDisposable {
       return;
     }
 
-    this.debuggerModel.callstackModel.currentFrameChanged.connect(
+    this.debuggerModel.callstack.currentFrameChanged.connect(
       this.onCurrentFrameChanged,
       this
     );
 
-    this.debuggerModel.sourcesModel.currentSourceOpened.connect(
+    this.debuggerModel.sources.currentSourceOpened.connect(
       this.onCurrentSourceOpened,
       this
     );
 
-    this.debuggerModel.breakpointsModel.clicked.connect(
-      async (_, breakpoint) => {
-        const path = breakpoint.source.path;
-        let source = await this.debuggerService.getSource({
-          sourceReference: 0,
-          path
-        });
-        this.onCurrentSourceOpened(null, source);
-      }
-    );
+    this.debuggerModel.breakpoints.clicked.connect(async (_, breakpoint) => {
+      const path = breakpoint.source.path;
+      let source = await this.debuggerService.getSource({
+        sourceReference: 0,
+        path
+      });
+      this.onCurrentSourceOpened(null, source);
+    });
   }
 
   protected onCurrentFrameChanged(_: Callstack.Model, frame: Callstack.IFrame) {
@@ -153,7 +151,7 @@ export class TrackerHandler implements IDisposable {
     this.shell.add(widget, 'main');
     void this.readOnlyEditorTracker.add(widget);
 
-    const frame = this.debuggerModel?.callstackModel.frame;
+    const frame = this.debuggerModel?.callstack.frame;
     if (frame) {
       EditorHandler.showCurrentLine(editor, frame.line);
     }

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -173,20 +173,20 @@ describe('DebugService', () => {
 
     describe('#updateBreakpoints', () => {
       it('should update the breakpoints', () => {
-        const bpList = model.breakpointsModel.getBreakpoints(sourceId);
+        const bpList = model.breakpoints.getBreakpoints(sourceId);
         expect(bpList).to.deep.eq(breakpoints);
       });
     });
 
     describe('#restoreState', () => {
       it('should restore the breakpoints', async () => {
-        model.breakpointsModel.restoreBreakpoints(
+        model.breakpoints.restoreBreakpoints(
           new Map<string, IDebugger.IBreakpoint[]>()
         );
-        const bpList1 = model.breakpointsModel.getBreakpoints(sourceId);
+        const bpList1 = model.breakpoints.getBreakpoints(sourceId);
         expect(bpList1.length).to.equal(0);
         await service.restoreState(true);
-        const bpList2 = model.breakpointsModel.getBreakpoints(sourceId);
+        const bpList2 = model.breakpoints.getBreakpoints(sourceId);
         expect(bpList2).to.deep.eq(breakpoints);
       });
     });
@@ -194,11 +194,11 @@ describe('DebugService', () => {
     describe('#restart', () => {
       it('should restart the debugger and send the breakpoints again', async () => {
         await service.restart();
-        model.breakpointsModel.restoreBreakpoints(
+        model.breakpoints.restoreBreakpoints(
           new Map<string, IDebugger.IBreakpoint[]>()
         );
         await service.restoreState(true);
-        const bpList = model.breakpointsModel.getBreakpoints(sourceId);
+        const bpList = model.breakpoints.getBreakpoints(sourceId);
         breakpoints[0].id = 2;
         breakpoints[1].id = 3;
         expect(bpList).to.deep.eq(breakpoints);

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -73,7 +73,7 @@ describe('DebugService', () => {
     await (client as ClientSession).initialize();
     await client.kernel.ready;
     session = new DebugSession({ client });
-    model = new Debugger.Model({});
+    model = new Debugger.Model();
     service = new DebugService();
   });
 


### PR DESCRIPTION
This was briefly discussed a while ago. Having `model` as suffix to reference a model is might be unnecessary.

### Changes

- something like `this.model.callstackModel.frame` becomes `this.model.callstack.frame`
- remove unused `Debugger.Model.IOptions`