### PR TITLE
Check debugging is enabled before restoring the session

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -41,10 +41,11 @@ export class DebugService implements IDebugger, IDisposable {
   }
 
   /**
-   * Whether debugging is enabled for the current session.
+   * Request whether debugging is enabled for the current session.
    */
-  get isDebuggingEnabled(): boolean {
-    return this._session.kernelInfo?.debugger ?? false;
+  async requestDebuggingEnabled(): Promise<boolean> {
+    const kernelInfo = await this._session?.requestKernelInfo();
+    return kernelInfo?.debugger ?? false;
   }
 
   /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -66,7 +66,7 @@ export class DebugSession implements IDebugger.ISession {
       this._client.iopubMessage.connect(this._handleEvent, this);
 
       if (this.client instanceof ClientSession) {
-        this._ready = this.client.ready;
+        this._ready = this.client.ready.then(_ => this.client.kernel.ready);
       } else {
         this._ready = this.client.kernel.ready;
       }
@@ -74,9 +74,11 @@ export class DebugSession implements IDebugger.ISession {
   }
 
   /**
-   * Return the kernel info for the debug session.
+   * Return the kernel info for the debug session, waiting for the
+   * kernel to be ready.
    */
-  get kernelInfo(): IDebugger.ISession.IInfoReply | null {
+  async requestKernelInfo(): Promise<IDebugger.ISession.IInfoReply | null> {
+    await this._ready;
     return (this.client.kernel?.info as IDebugger.ISession.IInfoReply) ?? null;
   }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -18,11 +18,6 @@ import { DebugProtocol } from 'vscode-debugprotocol';
  */
 export interface IDebugger {
   /**
-   * Whether debugging is enabled for the current session.
-   */
-  readonly isDebuggingEnabled: boolean;
-
-  /**
    * The current debugger session.
    */
   session: IDebugger.ISession;
@@ -46,6 +41,11 @@ export interface IDebugger {
    * Signal emitted for debug event messages.
    */
   readonly eventMessage: ISignal<IDebugger, IDebugger.ISession.Event>;
+
+  /**
+   * Request whether debugging is enabled for the current session.
+   */
+  requestDebuggingEnabled(): Promise<boolean>;
 
   /**
    * Computes an id based on the given code.
@@ -145,11 +145,6 @@ export namespace IDebugger {
     client: IClientSession | Session.ISession;
 
     /**
-     * The kernel info for the debug session.
-     */
-    readonly kernelInfo: IDebugger.ISession.IInfoReply | null;
-
-    /**
      * Whether the debug session is started
      */
     readonly isStarted: boolean;
@@ -161,6 +156,12 @@ export namespace IDebugger {
       IDebugger.ISession,
       IDebugger.ISession.Event
     >;
+
+    /**
+     * Return the kernel info for the debug session, waiting for the
+     * kernel to be ready.
+     */
+    requestKernelInfo(): Promise<IDebugger.ISession.IInfoReply | null>;
 
     /**
      * Start a new debug session.

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -41,19 +41,21 @@ describe('Debugging Support', () => {
     await Promise.all([xpythonClient.shutdown(), ipykernelClient.shutdown()]);
   });
 
-  describe('#isDebuggingEnabled', () => {
-    it('should return true for kernels that have support for debugging', () => {
+  describe('#requestDebuggingEnabled', () => {
+    it('should return true for kernels that have support for debugging', async () => {
       const debugSession = new DebugSession({ client: xpythonClient });
       let service = new DebugService();
       service.session = debugSession;
-      expect(service.isDebuggingEnabled).to.be.true;
+      const enabled = await service.requestDebuggingEnabled();
+      expect(enabled).to.be.true;
     });
 
-    it('should return false for kernels that do not have support for debugging', () => {
+    it('should return false for kernels that do not have support for debugging', async () => {
       const debugSession = new DebugSession({ client: ipykernelClient });
       let service = new DebugService();
       service.session = debugSession;
-      expect(service.isDebuggingEnabled).to.be.false;
+      const enabled = await service.requestDebuggingEnabled();
+      expect(enabled).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Fixes #268.

Check whether a kernel support debugging before restoring the session and sending the `debugInfo` message.