### PR TITLE
Dispose the session on debugger closed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ class DebuggerHandler<
         return;
       }
       await debug.stop();
+      debug.session.dispose();
       debug.session = null;
       handlerIds.forEach(id => {
         this.handlers[id].dispose();


### PR DESCRIPTION
The session can be disposed before setting it to `null` when the debugger is closed.