### PR TITLE
Fix enabled commands on debugger closed

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -65,8 +65,8 @@ export namespace Debugger {
       if (this.isDisposed) {
         return;
       }
-      this.service.model = null;
       this.model.dispose();
+      this.service.model = null;
     }
 
     readonly model: Debugger.Model;

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export namespace CommandIDs {
 
   export const debugConsole = 'debugger:debug-console';
 
-  export const closeDebugger = 'debugger:close';
+  export const close = 'debugger:close';
 }
 
 async function setDebugSession(
@@ -264,8 +264,11 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
 
     let sidebar: Debugger.Sidebar;
 
-    commands.addCommand(CommandIDs.closeDebugger, {
+    commands.addCommand(CommandIDs.close, {
       label: 'Close Debugger',
+      isEnabled: () => {
+        return !!sidebar;
+      },
       execute: () => {
         if (!sidebar) {
           return;
@@ -273,11 +276,12 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
         sidebar.close();
         sidebar.dispose();
         sidebar = null;
+        commands.notifyCommandChanged();
       }
     });
 
     app.contextMenu.addItem({
-      command: CommandIDs.closeDebugger,
+      command: CommandIDs.close,
       selector: '.jp-DebuggerSidebar'
     });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -147,7 +147,7 @@ export class DebugService implements IDebugger, IDisposable {
    * Whether there exists a thread in stopped state.
    */
   hasStoppedThreads(): boolean {
-    return this._model?.stoppedThreads.size !== 0 ?? false;
+    return this._model?.stoppedThreads.size > 0 ?? false;
   }
 
   /**


### PR DESCRIPTION
Commands were not properly disabled when the debugger sidebar was closed.

This change should fix it.

### Before

![close-debugger-update-commands2](https://user-images.githubusercontent.com/591645/70722445-9cb79c00-1cf7-11ea-8faa-2cfedd34cf2a.gif)

### After

![close-debugger-update-commands](https://user-images.githubusercontent.com/591645/70722453-9fb28c80-1cf7-11ea-8a8e-e6f90058b594.gif)
