### PR TITLE
Cleanup up sub-model constructors

### DIFF
--- a/src/callstack/index.ts
+++ b/src/callstack/index.ts
@@ -88,10 +88,6 @@ export namespace Callstack {
   export interface IFrame extends DebugProtocol.StackFrame {}
 
   export class Model {
-    constructor(model: IFrame[]) {
-      this._state = model;
-    }
-
     set frames(newFrames: IFrame[]) {
       this._state = newFrames;
       // default to the new frame is the previous one can't be found
@@ -122,7 +118,7 @@ export namespace Callstack {
       return this._currentFrameChanged;
     }
 
-    private _state: IFrame[];
+    private _state: IFrame[] = [];
     private _currentFrame: IFrame;
     private _framesChanged = new Signal<this, IFrame[]>(this);
     private _currentFrameChanged = new Signal<this, IFrame>(this);

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -30,8 +30,6 @@ export namespace Debugger {
       this.title.iconClass = 'jp-BugIcon jp-SideBar-tabIcon';
       this.orientation = 'vertical';
 
-      this.addClass('jp-DebuggerSidebar');
-
       const { callstackCommands, editorServices, service } = options;
 
       this.model = new Debugger.Model();
@@ -39,14 +37,17 @@ export namespace Debugger {
       this.service.model = this.model;
 
       this.variables = new Variables({ model: this.model.variables });
+
       this.callstack = new Callstack({
         commands: callstackCommands,
         model: this.model.callstack
       });
+
       this.breakpoints = new Breakpoints({
         service,
         model: this.model.breakpoints
       });
+
       this.sources = new Sources({
         model: this.model.sources,
         service,
@@ -57,6 +58,8 @@ export namespace Debugger {
       this.addWidget(this.callstack);
       this.addWidget(this.breakpoints);
       this.addWidget(this.sources);
+
+      this.addClass('jp-DebuggerSidebar');
     }
 
     isDisposed: boolean;
@@ -80,8 +83,8 @@ export namespace Debugger {
   export class Model implements IDebugger.IModel {
     constructor() {
       this.breakpoints = new Breakpoints.Model();
-      this.callstack = new Callstack.Model([]);
-      this.variables = new Variables.Model([]);
+      this.callstack = new Callstack.Model();
+      this.variables = new Variables.Model();
       this.sources = new Sources.Model({
         currentFrameChanged: this.callstack.currentFrameChanged
       });

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -61,10 +61,6 @@ export namespace Variables {
   }
 
   export class Model {
-    constructor(model: IScope[] = []) {
-      this._state = model;
-    }
-
     get changed(): ISignal<this, void> {
       return this._changed;
     }
@@ -86,7 +82,7 @@ export namespace Variables {
       this._variableExpanded.emit(variable);
     }
 
-    protected _state: IScope[];
+    protected _state: IScope[] = [];
     private _variableExpanded = new Signal<this, IVariable>(this);
     private _changed = new Signal<this, void>(this);
   }


### PR DESCRIPTION
A quick cleanup to remove some unused parameters passed to `Callstack.Model` and `Variables.Model`.