### PR TITLE
Format breakpoint files to follow the code style

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -2,24 +2,41 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { ReactWidget } from '@jupyterlab/apputils';
+
 import React, { useEffect, useState } from 'react';
+
 import { Breakpoints } from '.';
+
 import { IDebugger } from '../tokens';
 
+/**
+ * The body for a Breakpoints Panel.
+ */
 export class Body extends ReactWidget {
+  /**
+   * Instantiate a new Body for the Breakpoints Panel.
+   * @param model The model for the breakpoints.
+   */
   constructor(model: Breakpoints.Model) {
     super();
-    this.model = model;
+    this._model = model;
     this.addClass('jp-DebuggerBreakpoints-body');
   }
 
+  /**
+   * Render the BreakpointsComponent.
+   */
   render() {
-    return <BreakpointsComponent model={this.model} />;
+    return <BreakpointsComponent model={this._model} />;
   }
 
-  readonly model: Breakpoints.Model;
+  private _model: Breakpoints.Model;
 }
 
+/**
+ * A React component to display a list of breakpoints.
+ * @param model The model for the breakpoints.
+ */
 const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
   const [breakpoints, setBreakpoints] = useState(
     Array.from(model.breakpoints.entries())
@@ -59,6 +76,11 @@ const BreakpointsComponent = ({ model }: { model: Breakpoints.Model }) => {
   );
 };
 
+/**
+ * A React Component to display breakpoints grouped by source file.
+ * @param breakpoints The list of breakpoints.
+ * @param model The model for the breakpoints.
+ */
 const BreakpointCellComponent = ({
   breakpoints,
   model
@@ -83,6 +105,11 @@ const BreakpointCellComponent = ({
   );
 };
 
+/**
+ * A React Component to display a single breakpoint.
+ * @param breakpoints The breakpoint.
+ * @param model The model for the breakpoints.
+ */
 const BreakpointComponent = ({
   breakpoint,
   model
@@ -92,12 +119,14 @@ const BreakpointComponent = ({
 }) => {
   return (
     <div
-      className={`breakpoint`}
+      className={`jp-DebuggerBreakpoint`}
       onClick={() => model.clicked.emit(breakpoint)}
       title={breakpoint.source.path}
     >
-      <span className={'marker'}>●</span>
-      <span className={'source'}>{breakpoint.source.path}</span>
+      <span className={'jp-DebuggerBreakpoint-marker'}>●</span>
+      <span className={'jp-DebuggerBreakpoint-source'}>
+        {breakpoint.source.path}
+      </span>
       <span>{breakpoint.line}</span>
     </div>
   );

--- a/src/breakpoints/index.ts
+++ b/src/breakpoints/index.ts
@@ -2,8 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Toolbar, ToolbarButton } from '@jupyterlab/apputils';
+
 import { IDisposable } from '@phosphor/disposable';
-import { Signal } from '@phosphor/signaling';
+
+import { ISignal, Signal } from '@phosphor/signaling';
 
 import { Panel, PanelLayout, Widget } from '@phosphor/widgets';
 
@@ -11,74 +13,110 @@ import { IDebugger } from '../tokens';
 
 import { Body } from './body';
 
+/**
+ * A Panel to show a list of breakpoints.
+ */
 export class Breakpoints extends Panel {
+  /**
+   * Instantiate a new Breakpoints Panel.
+   * @param options The instantiation options for a Breakpoints Panel.
+   */
   constructor(options: Breakpoints.IOptions) {
     super();
-    this.model = options.model;
-    this.service = options.service;
-    this.addClass('jp-DebuggerBreakpoints');
+    const { model, service } = options;
 
     const header = new BreakpointsHeader();
-    this.body = new Body(this.model);
-
-    this.addWidget(header);
-    this.addWidget(this.body);
+    const body = new Body(model);
 
     header.toolbar.addItem(
       'closeAll',
       new ToolbarButton({
         iconClassName: 'jp-CloseAllIcon',
         onClick: () => {
-          void this.service.clearBreakpoints();
+          void service.clearBreakpoints();
         },
         tooltip: 'Remove All Breakpoints'
       })
     );
-  }
 
-  readonly body: Widget;
-  readonly model: Breakpoints.Model;
-  readonly service: IDebugger;
+    this.addWidget(header);
+    this.addWidget(body);
+
+    this.addClass('jp-DebuggerBreakpoints');
+  }
 }
 
+/**
+ * The header for a Breakpoints Panel.
+ */
 class BreakpointsHeader extends Widget {
+  /**
+   * Instantiate a new BreakpointsHeader.
+   */
   constructor() {
     super({ node: document.createElement('header') });
 
-    const layout = new PanelLayout();
     const title = new Widget({ node: document.createElement('h2') });
-
-    this.layout = layout;
     title.node.textContent = 'Breakpoints';
+
+    const layout = new PanelLayout();
     layout.addWidget(title);
     layout.addWidget(this.toolbar);
+    this.layout = layout;
   }
 
+  /**
+   * The toolbar for the breakpoints header.
+   */
   readonly toolbar = new Toolbar();
 }
 
+/**
+ * A namespace for Breakpoints `statics`.
+ */
 export namespace Breakpoints {
+  /**
+   * A model for a list of breakpoints.
+   */
   export class Model implements IDisposable {
-    get changed(): Signal<this, IDebugger.IBreakpoint[]> {
-      return this._changed;
-    }
-
-    get restored(): Signal<this, void> {
-      return this._restored;
-    }
-
-    get clicked(): Signal<this, IDebugger.IBreakpoint> {
-      return this._clicked;
-    }
-
-    get breakpoints(): Map<string, IDebugger.IBreakpoint[]> {
-      return this._breakpoints;
-    }
-
+    /**
+     * Whether the model is disposed.
+     */
     get isDisposed(): boolean {
       return this._isDisposed;
     }
 
+    /**
+     * Signal emitted when the model changes.
+     */
+    get changed(): ISignal<this, IDebugger.IBreakpoint[]> {
+      return this._changed;
+    }
+
+    /**
+     * Signal emitted when the breakpoints are restored.
+     */
+    get restored(): Signal<this, void> {
+      return this._restored;
+    }
+
+    /**
+     * Signal emitted when a breakpoint is clicked.
+     */
+    get clicked(): Signal<this, IDebugger.IBreakpoint> {
+      return this._clicked;
+    }
+
+    /**
+     * Get all the breakpoints.
+     */
+    get breakpoints(): Map<string, IDebugger.IBreakpoint[]> {
+      return this._breakpoints;
+    }
+
+    /**
+     * Dispose the model.
+     */
     dispose(): void {
       if (this._isDisposed) {
         return;
@@ -87,34 +125,52 @@ export namespace Breakpoints {
       Signal.clearData(this);
     }
 
+    /**
+     * Set the breakpoints for a given id (path).
+     * @param id The code id (path).
+     * @param breakpoints The list of breakpoints.
+     */
     setBreakpoints(id: string, breakpoints: IDebugger.IBreakpoint[]) {
       this._breakpoints.set(id, breakpoints);
-      this.changed.emit(breakpoints);
+      this._changed.emit(breakpoints);
     }
 
+    /**
+     * Get the breakpoints for a given id (path).
+     * @param id The code id (path).
+     */
     getBreakpoints(id: string): IDebugger.IBreakpoint[] {
-      return this._breakpoints.get(id) || [];
+      return this._breakpoints.get(id) ?? [];
     }
 
+    /**
+     * Restore a map of breakpoints.
+     * @param breakpoints The map of breakpoints
+     */
     restoreBreakpoints(breakpoints: Map<string, IDebugger.IBreakpoint[]>) {
       this._breakpoints = breakpoints;
       this._restored.emit();
     }
 
+    private _isDisposed = false;
     private _breakpoints = new Map<string, IDebugger.IBreakpoint[]>();
     private _changed = new Signal<this, IDebugger.IBreakpoint[]>(this);
     private _restored = new Signal<this, void>(this);
     private _clicked = new Signal<this, IDebugger.IBreakpoint>(this);
-    private _isDisposed: boolean = false;
   }
 
   /**
-   * Instantiation options for `Breakpoints`;
+   * Instantiation options for `Breakpoints`.
    */
   export interface IOptions extends Panel.IOptions {
+    /**
+     * The debugger model.
+     */
     model: Model;
+
+    /**
+     * The debugger service.
+     */
     service: IDebugger;
   }
 }
-
-export type SessionTypes = 'console' | 'notebook';

--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -21,7 +21,7 @@ import { Debugger } from '../debugger';
 
 import { IDebugger } from '../tokens';
 
-const LINE_HIGHLIGHT_CLASS = 'jp-breakpoint-line-highlight';
+const LINE_HIGHLIGHT_CLASS = 'jp-DebuggerEditor-highlight';
 
 const EDITOR_CHANGED_TIMEOUT = 1000;
 
@@ -273,7 +273,7 @@ export interface ILineInfo {
 namespace Private {
   export function createMarkerNode() {
     let marker = document.createElement('div');
-    marker.className = 'jp-breakpoint-marker';
+    marker.className = 'jp-DebuggerEditor-marker';
     marker.innerHTML = '●';
     return marker;
   }

--- a/style/breakpoints.css
+++ b/style/breakpoints.css
@@ -7,38 +7,27 @@
   padding: 10px;
 }
 
-.jp-DebuggerBreakpoints-body .breakpoint .marker {
+.jp-DebuggerBreakpoint {
+  display: flex;
+  align-items: center;
+}
+
+.jp-DebuggerBreakpoint:hover {
+  background: var(--jp-layout-color2);
+  cursor: pointer;
+}
+
+.jp-DebuggerBreakpoint-marker {
   font-size: 20px;
   padding-right: 5px;
   content: '●';
   color: var(--jp-error-color1);
 }
 
-.jp-DebuggerBreakpoints-body .breakpoint {
-  display: flex;
-  align-items: center;
-}
-
-.jp-DebuggerBreakpoints-body .breakpoint .source {
+.jp-DebuggerBreakpoint-source {
   flex-grow: 1;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.jp-DebuggerBreakpoints-body .breakpoint:hover {
-  background: var(--jp-layout-color2);
-  cursor: pointer;
-}
-
-.jp-breakpoint-marker {
-  position: absolute;
-  left: -34px;
-  top: -1px;
-  color: var(--jp-error-color1);
-}
-
-.jp-breakpoint-line-highlight {
-  background-color: var(--jp-warn-color0);
 }
 
 [data-jp-debugger='true'] .CodeMirror-gutter-wrapper::after {

--- a/style/editor.css
+++ b/style/editor.css
@@ -1,0 +1,15 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-DebuggerEditor-highlight {
+  background-color: var(--jp-warn-color0);
+}
+
+.jp-DebuggerEditor-marker {
+  position: absolute;
+  left: -34px;
+  top: -1px;
+  color: var(--jp-error-color1);
+}

--- a/style/index.css
+++ b/style/index.css
@@ -2,9 +2,10 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
-@import './variables.css';
-@import './callstack.css';
 @import './breakpoints.css';
+@import './editor.css';
+@import './callstack.css';
+@import './variables.css';
 
 @import './icons.css';
 @import './sidebar.css';


### PR DESCRIPTION
Part of #139:

- Format according to the style guide
- Rename CSS class name for the highlight and markers in the editors.
- Remove some `readonly` public attributes (not required)