### PR TITLE
Breakpoints removed from the sidebar on notebook closed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,7 @@ const notebooks: JupyterFrontEndPlugin<void> = {
 
     labShell.currentChanged.connect(async (_, update) => {
       const widget = update.newValue;
+
       if (!(widget instanceof NotebookPanel)) {
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,11 @@ class DebuggerHandler<
       handler.dispose();
       delete this._handlers[widget.id];
       updateAttribute();
+      const handlerIds = Object.keys(this._handlers);
+      if (handlerIds.length !== 0) {
+        return;
+      }
+      debug.clearUIBreakpoints();
     };
 
     const toggleDebugging = async () => {

--- a/src/service.ts
+++ b/src/service.ts
@@ -363,6 +363,11 @@ export class DebugService implements IDebugger, IDisposable {
     this._model.breakpoints.restoreBreakpoints(bpMap);
   }
 
+  clearUIBreakpoints() {
+    let bpMap = new Map<string, IDebugger.IBreakpoint[]>();
+    this._model.breakpoints.restoreBreakpoints(bpMap);
+  }
+
   /**
    * Retrieve the content of a source file.
    * @param source The source object containing the path to the file.

--- a/src/service.ts
+++ b/src/service.ts
@@ -351,11 +351,13 @@ export class DebugService implements IDebugger, IDisposable {
       return;
     }
 
-    this._model.breakpoints.breakpoints.forEach(
-      async (breakpoints, path, _) => {
-        await this._setBreakpoints([], path);
-      }
-    );
+    if (!this.session.client.isDisposed) {
+      this._model.breakpoints.breakpoints.forEach(
+        async (breakpoints, path, _) => {
+          await this._setBreakpoints([], path);
+        }
+      );
+    }
 
     let bpMap = new Map<string, IDebugger.IBreakpoint[]>();
     this._model.breakpoints.restoreBreakpoints(bpMap);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -126,6 +126,11 @@ export interface IDebugger {
   clearBreakpoints(): Promise<void>;
 
   /**
+   * Clear breakpoints only in sidebar
+   */
+  clearUIBreakpoints(): void;
+
+  /**
    * Retrieve the content of a source file.
    * @param source The source object containing the path to the file.
    */


### PR DESCRIPTION

Resolved by Jeremy in PR #308 












**This branch needs to be rebased and refactored after this PR #290** 


resolve issue #168.

- [x] after close all notebooks clear breakpoints.

After close widget:

![clearBreakpoints](https://user-images.githubusercontent.com/34033913/70907964-713ff480-200a-11ea-8ff7-8b11ecd88054.gif)

