### PR TITLE
Update JupyterLab to 1.2 for Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A JupyterLab debugger UI extension.
 
 ## Prerequisites
 
-- JupyterLab 1.1+
+- JupyterLab 1.2+
 - xeus-python 0.6.7+
 
 ## Installation

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: jupyterlab-debugger
 channels:
 - conda-forge
 dependencies:
-- jupyterlab=1.1
+- jupyterlab=1.2
 - nodejs
 - notebook=6
 - ptvsd


### PR DESCRIPTION
Bump JupyterLab to 1.2 for Binder, because of an issue with the toggle button mentioned in #290. 