### PR TITLE
Move editor cleanup to the handler dispose method

### DIFF
--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -125,6 +125,8 @@ export class EditorHandler implements IDisposable {
       return;
     }
     const editor = this._editor as CodeMirrorEditor;
+    EditorHandler.clearHighlight(editor);
+    EditorHandler.clearGutter(editor);
     editor.setOption('lineNumbers', false);
     editor.editor.setOption('gutters', []);
     editor.editor.off('gutterClick', this.onGutterClick);

--- a/src/handlers/notebook.ts
+++ b/src/handlers/notebook.ts
@@ -33,7 +33,6 @@ export class NotebookHandler implements IDisposable {
       return;
     }
     this.isDisposed = true;
-    this.cleanAllCells();
     this._cellMap.values().forEach(handler => handler.dispose());
     this._cellMap.dispose();
     Signal.clearData(this);
@@ -49,14 +48,6 @@ export class NotebookHandler implements IDisposable {
       editor: codeCell.editor
     });
     this._cellMap.set(cell.model.id, editorHandler);
-  }
-
-  protected cleanAllCells() {
-    const cells = this.notebookPanel.content.widgets;
-    cells.forEach(cell => {
-      EditorHandler.clearHighlight(cell.editor);
-      EditorHandler.clearGutter(cell.editor);
-    });
   }
 
   protected onActiveCellChanged(notebook: Notebook, cell: Cell) {


### PR DESCRIPTION
A quick code cleanup.

Instead of iterating through all the cells in the notebook handler to clear the highlighting and breakpoint markers, we can do that in the `dispose` method of the `EditorHandler`.