### PR TITLE
Clear the sidebar UI

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -128,6 +128,18 @@ export namespace Debugger {
       this._stoppedThreads = threads;
     }
 
+    /**
+     * Clear the model.
+     */
+    clear() {
+      this._stoppedThreads.clear();
+      const breakpoints = new Map<string, IDebugger.IBreakpoint[]>();
+      this.breakpoints.restoreBreakpoints(breakpoints);
+      this.callstack.frames = [];
+      this.variables.scopes = [];
+      this.sources.currentSource = null;
+    }
+
     private _isDisposed = false;
     private _stoppedThreads = new Set<number>();
     private _disposed = new Signal<this, void>(this);

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -109,7 +109,10 @@ export class TrackerHandler implements IDisposable {
   }
 
   protected onCurrentFrameChanged(_: Callstack.Model, frame: Callstack.IFrame) {
-    const debugSessionPath = this.debuggerService.session.client.path;
+    const debugSessionPath = this.debuggerService.session?.client?.path;
+    if (!debugSessionPath) {
+      return;
+    }
     const source = frame?.source.path ?? null;
     each(this.find(debugSessionPath, source), editor => {
       requestAnimationFrame(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,12 +144,12 @@ class DebuggerHandler<
     if (kernelChangedHandler) {
       client.kernelChanged.disconnect(kernelChangedHandler);
     }
-    const updateHandler = () => {
-      void this._update(debug, widget, client);
+    const updateHandler = async () => {
+      return this._update(debug, widget, client);
     };
     client.kernelChanged.connect(updateHandler, this);
     this._kernelChangedHandlers[client.path] = updateHandler;
-    return this._update(debug, widget, client);
+    return updateHandler();
   }
 
   /**
@@ -194,6 +194,14 @@ class DebuggerHandler<
       }
       handler.dispose();
       delete this._handlers[widget.id];
+
+      // clear the model if the handler being removed corresponds
+      // to the current active debug session
+      if (debug.session?.client?.path === client.path) {
+        const model = debug.model as Debugger.Model;
+        model.clear();
+      }
+
       updateAttribute();
     };
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -180,12 +180,8 @@ export class DebugService implements IDebugger, IDisposable {
    */
   async stop(): Promise<void> {
     await this.session.stop();
-    if (this.model) {
-      // TODO: create a more generic cleanup method?
-      this._model.stoppedThreads.clear();
-      const breakpoints = new Map<string, IDebugger.IBreakpoint[]>();
-      this._model.breakpoints.restoreBreakpoints(breakpoints);
-      this._clearModel();
+    if (this._model) {
+      this._model.clear();
     }
   }
 


### PR DESCRIPTION
Fixes #168.

Alternative to #291. 

This introduces a new `clear()` method on the model to clear everything, and restore the breakpoints to an empty map.

This should also still support keeping the last debug session alive when switching between notebooks and widgets.

![clear-sidebar-ui](https://user-images.githubusercontent.com/591645/71174443-806eae80-2265-11ea-909c-c4af34884273.gif)

