### PR TITLE
Make breakpoints and callstack scrollable

### DIFF
--- a/style/breakpoints.css
+++ b/style/breakpoints.css
@@ -3,8 +3,14 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-DebuggerBreakpoints {
+  display: flex;
+  flex-direction: column;
+}
+
 .jp-DebuggerBreakpoints-body {
   padding: 10px;
+  overflow: auto;
 }
 
 .jp-DebuggerBreakpoint {

--- a/style/callstack.css
+++ b/style/callstack.css
@@ -3,6 +3,15 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-DebuggerCallstack {
+  display: flex;
+  flex-direction: column;
+}
+
+.jp-DebuggerCallstack-body {
+  overflow: auto;
+}
+
 .jp-DebuggerCallstack-body ul {
   list-style: none;
   margin: 0;

--- a/style/sidebar.css
+++ b/style/sidebar.css
@@ -20,6 +20,7 @@
   flex-direction: row;
   align-items: center;
   background-color: var(--jp-layout-color2);
+  min-height: 24px;
   height: 24px;
 }
 


### PR DESCRIPTION
Fixes #244.

![scrollable-breakpoints-callstack](https://user-images.githubusercontent.com/591645/71405153-e461f000-2634-11ea-9fa8-d56ea2ff0c4f.gif)
