### PR TITLE
Attempt at fixing the tests on CI

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -102,7 +102,6 @@ export class DebugSession implements IDebugger.ISession {
    * Start a new debug session
    */
   async start(): Promise<void> {
-    await this._ready();
     await this.sendRequest('initialize', {
       clientID: 'jupyterlab',
       clientName: 'JupyterLab',
@@ -125,7 +124,6 @@ export class DebugSession implements IDebugger.ISession {
    * Stop the running debug session.
    */
   async stop(): Promise<void> {
-    await this._ready();
     await this.sendRequest('disconnect', {
       restart: false,
       terminateDebuggee: true
@@ -137,7 +135,6 @@ export class DebugSession implements IDebugger.ISession {
    * Restore the state of a debug session.
    */
   async restoreState(): Promise<IDebugger.ISession.Response['debugInfo']> {
-    await this._ready();
     const message = await this.sendRequest('debugInfo', {});
     this._isStarted = message.body.isStarted;
     return message;

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -20,16 +20,16 @@ describe('Debugging support', () => {
   let ipykernel: ISessionContext;
 
   beforeAll(async () => {
-    xpython = await createSessionContext({
-      kernelPreference: {
-        name: 'xpython'
-      }
-    });
-    ipykernel = await createSessionContext({
-      kernelPreference: {
-        name: 'python3'
-      }
-    });
+    xpython = await createSessionContext();
+    xpython.kernelPreference = {
+      ...xpython.kernelPreference,
+      name: 'xpython'
+    };
+    ipykernel = await createSessionContext();
+    ipykernel.kernelPreference = {
+      ...ipykernel.kernelPreference,
+      name: 'python3'
+    };
     await Promise.all([xpython.initialize(), ipykernel.initialize()]);
     await Promise.all([
       xpython.session?.kernel?.info,
@@ -61,11 +61,11 @@ describe('DebuggerService', () => {
   let service: IDebugger;
 
   beforeEach(async () => {
-    sessionContext = await createSessionContext({
-      kernelPreference: {
-        name: 'xpython'
-      }
-    });
+    sessionContext = await createSessionContext();
+    sessionContext.kernelPreference = {
+      ...sessionContext.kernelPreference,
+      name: 'xpython'
+    };
     await sessionContext.initialize();
     await sessionContext.session.kernel.info;
     session = new DebugSession({ connection: sessionContext.session });

--- a/tests/src/service.spec.ts
+++ b/tests/src/service.spec.ts
@@ -67,7 +67,6 @@ describe('DebuggerService', () => {
       }
     });
     await sessionContext.initialize();
-    await sessionContext.ready;
     await sessionContext.session.kernel.info;
     session = new DebugSession({ connection: sessionContext.session });
     model = new DebuggerModel();

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -3,13 +3,13 @@
 
 import { expect } from 'chai';
 
-import { ISessionContext } from '@jupyterlab/apputils';
+import { Session } from '@jupyterlab/services';
 
-import { createSessionContext } from '@jupyterlab/testutils';
+import { createSession } from '@jupyterlab/testutils';
 
 import { find } from '@lumino/algorithm';
 
-import { PromiseDelegate } from '@lumino/coreutils';
+import { PromiseDelegate, UUID } from '@lumino/coreutils';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 
@@ -18,27 +18,26 @@ import { IDebugger } from '../../lib/tokens';
 import { DebugSession } from '../../lib/session';
 
 describe('DebugSession', () => {
-  let sessionContext: ISessionContext;
+  let connection: Session.ISessionConnection;
 
   beforeEach(async () => {
-    sessionContext = await createSessionContext();
-    sessionContext.kernelPreference = {
-      ...sessionContext.kernelPreference,
-      name: 'xpython'
-    };
-    await sessionContext.initialize();
-    await sessionContext.session?.kernel?.info;
+    const path = UUID.uuid4();
+    connection = await createSession({
+      name: '',
+      type: 'test',
+      path
+    });
+    await connection.changeKernel({ name: 'xpython' });
   });
 
   afterEach(async () => {
-    await sessionContext.shutdown();
-    sessionContext.dispose();
+    await connection.shutdown();
   });
 
   describe('#isDisposed', () => {
     it('should return whether the object is disposed', () => {
       const debugSession = new DebugSession({
-        connection: sessionContext.session
+        connection
       });
       expect(debugSession.isDisposed).to.equal(false);
       debugSession.dispose();
@@ -49,7 +48,7 @@ describe('DebugSession', () => {
   describe('#eventMessage', () => {
     it('should be emitted when sending debug messages', async () => {
       const debugSession = new DebugSession({
-        connection: sessionContext.session
+        connection
       });
       let events: string[] = [];
       debugSession.eventMessage.connect((sender, event) => {
@@ -64,7 +63,7 @@ describe('DebugSession', () => {
   describe('#sendRequest success', () => {
     it('should send debug messages to the kernel', async () => {
       const debugSession = new DebugSession({
-        connection: sessionContext.session
+        connection
       });
       await debugSession.start();
       const code = 'i=0\ni+=1\ni+=1';
@@ -79,7 +78,7 @@ describe('DebugSession', () => {
   describe('#sendRequest failure', () => {
     it('should handle replies with success false', async () => {
       const debugSession = new DebugSession({
-        connection: sessionContext.session
+        connection
       });
       await debugSession.start();
       const reply = await debugSession.sendRequest('evaluate', {
@@ -108,20 +107,20 @@ describe('protocol', () => {
     { line: 5 }
   ];
 
-  let sessionContext: ISessionContext;
+  let connection: Session.ISessionConnection;
   let debugSession: DebugSession;
   let threadId: number = 1;
 
   beforeEach(async () => {
-    sessionContext = await createSessionContext();
-    sessionContext.kernelPreference = {
-      ...sessionContext.kernelPreference,
-      name: 'xpython'
-    };
-    await sessionContext.initialize();
-    await sessionContext.session?.kernel?.info;
+    const path = UUID.uuid4();
+    connection = await createSession({
+      name: '',
+      type: 'test',
+      path
+    });
+    await connection.changeKernel({ name: 'xpython' });
     debugSession = new DebugSession({
-      connection: sessionContext.session
+      connection
     });
     await debugSession.start();
 
@@ -153,7 +152,7 @@ describe('protocol', () => {
     await debugSession.sendRequest('configurationDone', {});
 
     // trigger an execute_request
-    sessionContext.session.kernel.requestExecute({ code });
+    connection.kernel.requestExecute({ code });
 
     // wait for the first stopped event
     await stoppedFuture.promise;
@@ -162,8 +161,8 @@ describe('protocol', () => {
   afterEach(async () => {
     await debugSession.stop();
     debugSession.dispose();
-    await sessionContext.shutdown();
-    sessionContext.dispose();
+    await connection.shutdown();
+    connection.dispose();
   });
 
   describe('#debugInfo', () => {

--- a/tests/src/session.spec.ts
+++ b/tests/src/session.spec.ts
@@ -27,12 +27,12 @@ describe('DebugSession', () => {
       }
     });
     await sessionContext.initialize();
-    await sessionContext.ready;
     await sessionContext.session?.kernel?.info;
   });
 
   afterEach(async () => {
     await sessionContext.shutdown();
+    sessionContext.dispose();
   });
 
   describe('#isDisposed', () => {
@@ -121,8 +121,7 @@ describe('protocol', () => {
       }
     });
     await sessionContext.initialize();
-    await sessionContext.ready;
-    await sessionContext.session.kernel.info;
+    await sessionContext.session?.kernel?.info;
     debugSession = new DebugSession({
       connection: sessionContext.session
     });


### PR DESCRIPTION
This is an attempt at fixing the tests on CI, by using the same pattern as in core JupyterLab when it comes to initializing the session context and waiting for the kernel to be ready.