### PR TITLE
Use LabIcon from ui-components for BugIcon

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@jupyterlab/observables": "^3.0.0-beta.2",
     "@jupyterlab/notebook": "^2.0.0-beta.2",
     "@jupyterlab/services": "^5.0.0-beta.2",
+    "@jupyterlab/ui-components": "^2.0.0-beta.2",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/coreutils": "^1.3.1",
     "@lumino/disposable": "^1.2.0",

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -3,6 +3,8 @@
 
 import { IEditorServices } from '@jupyterlab/codeeditor';
 
+import { bugIcon } from '@jupyterlab/ui-components';
+
 import { Panel, SplitPanel, Widget } from '@lumino/widgets';
 
 import { Breakpoints } from './breakpoints';
@@ -34,7 +36,7 @@ export namespace Debugger {
     constructor(options: Sidebar.IOptions) {
       super();
       this.id = 'jp-debugger-sidebar';
-      this.title.iconClass = 'jp-BugIcon jp-SideBar-tabIcon';
+      this.title.iconRenderer = bugIcon;
       this.addClass('jp-DebuggerSidebar');
 
       const { callstackCommands, editorServices, service } = options;


### PR DESCRIPTION
Fixes #355.

![image](https://user-images.githubusercontent.com/591645/74135937-82157c80-4bed-11ea-825b-33c8f9015870.png)

![image](https://user-images.githubusercontent.com/591645/74135952-8a6db780-4bed-11ea-987a-1c2a6a3d2363.png)


More info about the new `LabIcon` in:

- https://jupyterlab.readthedocs.io/en/latest/developer/extension_migration.html#using-the-new-icon-system-and-labicon
- https://github.com/jupyterlab/jupyterlab/tree/master/packages/ui-components#readme
- Example use for the file browser in the left area: https://github.com/jupyterlab/jupyterlab/blob/f17361c2d6ecf1b5ccae5b576266355150f09af2/packages/filebrowser-extension/src/index.ts#L296