### PR TITLE
Add a variable filter to the settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@jupyterlab/observables": "^3.0.0",
     "@jupyterlab/notebook": "^2.0.0",
     "@jupyterlab/services": "^5.0.0",
+    "@jupyterlab/settingregistry": "^2.0.0",
     "@jupyterlab/ui-components": "^2.0.0",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/coreutils": "^1.3.1",

--- a/schema/main.json
+++ b/schema/main.json
@@ -1,6 +1,8 @@
 {
   "title": "Debugger",
-  "description": "Debugger settings.",
+  "description": "Debugger settings",
+  "jupyter.lab.setting-icon": "ui-components:bug",
+  "jupyter.lab.setting-icon-label": "Debugger",
   "jupyter.lab.shortcuts": [
     {
       "command": "debugger:debug-console",
@@ -18,7 +20,24 @@
       "selector": ".jp-Notebook"
     }
   ],
-  "properties": {},
+  "properties": {
+    "variableFilter": {
+      "title": "Variable filter",
+      "description": "Variables to filter out in the tree and table viewers",
+      "type": "array",
+      "default": [
+        "display",
+        "ptvsd",
+        "__annotations__",
+        "__builtins__",
+        "__doc__",
+        "__loader__",
+        "__name__",
+        "__package__",
+        "__spec__"
+      ]
+    }
+  },
   "additionalProperties": false,
   "type": "object"
 }

--- a/schema/main.json
+++ b/schema/main.json
@@ -20,22 +20,33 @@
       "selector": ".jp-Notebook"
     }
   ],
+  "definitions": {
+    "variableFilters": {
+      "properties": {
+        "xpython": {
+          "type": "array"
+        }
+      }
+    }
+  },
   "properties": {
-    "variableFilter": {
+    "variableFilters": {
       "title": "Variable filter",
       "description": "Variables to filter out in the tree and table viewers",
-      "type": "array",
-      "default": [
-        "display",
-        "ptvsd",
-        "__annotations__",
-        "__builtins__",
-        "__doc__",
-        "__loader__",
-        "__name__",
-        "__package__",
-        "__spec__"
-      ]
+      "$ref": "#/definitions/variableFilters",
+      "default": {
+        "xpython": [
+          "display",
+          "ptvsd",
+          "__annotations__",
+          "__builtins__",
+          "__doc__",
+          "__loader__",
+          "__name__",
+          "__package__",
+          "__spec__"
+        ]
+      }
     }
   },
   "additionalProperties": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import { IEditorServices } from '@jupyterlab/codeeditor';
 
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
 import { DocumentWidget } from '@jupyterlab/docregistry';
 
 import { FileEditor, IEditorTracker } from '@jupyterlab/fileeditor';
@@ -315,14 +317,15 @@ const variables: JupyterFrontEndPlugin<void> = {
 const main: JupyterFrontEndPlugin<IDebugger> = {
   id: '@jupyterlab/debugger:main',
   requires: [IEditorServices],
-  optional: [ILayoutRestorer, ICommandPalette],
+  optional: [ILayoutRestorer, ICommandPalette, ISettingRegistry],
   provides: IDebugger,
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     editorServices: IEditorServices,
     restorer: ILayoutRestorer | null,
-    palette: ICommandPalette | null
+    palette: ICommandPalette | null,
+    settings: ISettingRegistry | null
   ): IDebugger => {
     const { commands, shell } = app;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,13 +411,20 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
     if (settingRegistry) {
       const setting = await settingRegistry.load(main.id);
       const updateVariableSettings = () => {
-        const list = setting.get('variableFilter').composite as string[];
-        const variableFilter = new Set<string>(list);
-        sidebar.variables.filter = variableFilter;
+        const filters = setting.get('variableFilters').composite as {
+          [key: string]: string[];
+        };
+        const kernelName = service.session?.connection?.kernel?.name;
+        const list = filters[kernelName];
+        if (!list) {
+          return;
+        }
+        sidebar.variables.filter = new Set<string>(list);
       };
 
       updateVariableSettings();
       setting.changed.connect(updateVariableSettings);
+      sidebar.service.sessionChanged.connect(updateVariableSettings);
     }
 
     sidebar.service.eventMessage.connect(_ => {

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -64,9 +64,13 @@ export class Variables extends Panel {
     this.addClass('jp-DebuggerVariables');
   }
 
-  private _header: VariablesHeader;
-  private _tree: Widget;
-  private _table: Widget;
+  /**
+   * Set the variable filter for both the tree and table views.
+   */
+  set filter(filter: Set<string>) {
+    this._tree.filter = filter;
+    this._table.filter = filter;
+  }
 
   /**
    * A message handler invoked on a `'resize'` message.
@@ -85,6 +89,10 @@ export class Variables extends Panel {
     this._table.node.style.height = `${height}px`;
     this._tree.node.style.height = `${height}px`;
   }
+
+  private _header: VariablesHeader;
+  private _tree: VariablesBodyTree;
+  private _table: VariablesBodyTable;
 }
 
 /**

--- a/src/variables/table.tsx
+++ b/src/variables/table.tsx
@@ -44,10 +44,19 @@ export class VariablesBodyTable extends ReactWidget {
             key={scope.name}
             data={scope.variables}
             commands={this._commands}
+            filter={this._filter}
           />
         ))}
       </>
     );
+  }
+
+  /**
+   * Set the variable filter list.
+   */
+  set filter(filter: Set<string>) {
+    this._filter = filter;
+    this.update();
   }
 
   /**
@@ -63,6 +72,7 @@ export class VariablesBodyTable extends ReactWidget {
   }
 
   private _scopes: VariablesModel.IScope[] = [];
+  private _filter = new Set<string>();
   private _commands: CommandRegistry;
 }
 
@@ -113,13 +123,16 @@ export class VariableDetails extends ReactWidget {
  * A React component to display a table of variables.
  * @param data An array of variables.
  * @param service The debugger service.
+ * @param filter Optional variable filter list.
  */
 const VariablesComponent = ({
   data,
-  commands
+  commands,
+  filter
 }: {
   data: VariablesModel.IVariable[];
   commands: CommandRegistry;
+  filter?: Set<string>;
 }) => {
   const [variables, setVariables] = useState(data);
   const [selected, setSelected] = useState(null);
@@ -147,19 +160,21 @@ const VariablesComponent = ({
 
   const Tbody = (variables: VariablesModel.IVariable[]) => (
     <tbody>
-      {variables?.map(variable => (
-        <tr
-          onDoubleClick={() => onVariableDoubleClicked(variable)}
-          onClick={() => onVariableClicked(variable)}
-          key={variable.evaluateName}
-        >
-          <td>{variable.name}</td>
-          <td>{variable.type}</td>
-          <td className={selected === variable ? 'selected' : ''}>
-            {variable.value}
-          </td>
-        </tr>
-      ))}
+      {variables
+        ?.filter(variable => !filter.has(variable.evaluateName))
+        .map(variable => (
+          <tr
+            onDoubleClick={() => onVariableDoubleClicked(variable)}
+            onClick={() => onVariableClicked(variable)}
+            key={variable.evaluateName}
+          >
+            <td>{variable.name}</td>
+            <td>{variable.type}</td>
+            <td className={selected === variable ? 'selected' : ''}>
+              {variable.value}
+            </td>
+          </tr>
+        ))}
     </tbody>
   );
 

--- a/src/variables/tree.tsx
+++ b/src/variables/tree.tsx
@@ -42,10 +42,19 @@ export class VariablesBodyTree extends ReactWidget {
             key={scope.name}
             service={this._service}
             data={scope.variables}
+            filter={this._filter}
           />
         ))}
       </>
     );
+  }
+
+  /**
+   * Set the variable filter list.
+   */
+  set filter(filter: Set<string>) {
+    this._filter = filter;
+    this.update();
   }
 
   /**
@@ -61,6 +70,7 @@ export class VariablesBodyTree extends ReactWidget {
   }
 
   private _scopes: VariablesModel.IScope[] = [];
+  private _filter = new Set<string>();
   private _service: IDebugger;
 }
 
@@ -68,13 +78,16 @@ export class VariablesBodyTree extends ReactWidget {
  * A React component to display a list of variables.
  * @param data An array of variables.
  * @param service The debugger service.
+ * @param filter Optional variable filter list.
  */
 const VariablesComponent = ({
   data,
-  service
+  service,
+  filter
 }: {
   data: VariablesModel.IVariable[];
   service: IDebugger;
+  filter?: Set<string>;
 }) => {
   const [variables, setVariables] = useState(data);
 
@@ -85,12 +98,19 @@ const VariablesComponent = ({
   return (
     <>
       <ul>
-        {variables.map(variable => {
-          const key = `${variable.evaluateName}-${variable.type}-${variable.value}`;
-          return (
-            <VariableComponent key={key} data={variable} service={service} />
-          );
-        })}
+        {variables
+          ?.filter(variable => !filter.has(variable.evaluateName))
+          .map(variable => {
+            const key = `${variable.evaluateName}-${variable.type}-${variable.value}`;
+            return (
+              <VariableComponent
+                key={key}
+                data={variable}
+                service={service}
+                filter={filter}
+              />
+            );
+          })}
       </ul>
     </>
   );
@@ -103,10 +123,12 @@ const VariablesComponent = ({
  */
 const VariableComponent = ({
   data,
-  service
+  service,
+  filter
 }: {
   data: VariablesModel.IVariable;
   service: IDebugger;
+  filter?: Set<string>;
 }) => {
   const [variable] = useState(data);
   const [expanded, setExpanded] = useState(null);
@@ -153,6 +175,7 @@ const VariableComponent = ({
           key={variable.name}
           data={details}
           service={service}
+          filter={filter}
         />
       )}
     </li>


### PR DESCRIPTION
Fixes #179. 

Add a list to the debugger settings to be able to hide variables from the UI by default.

The current list of hidden variables is as follows:

```json
[
  "display",
  "ptvsd",
  "__annotations__",
  "__builtins__",
  "__doc__",
  "__loader__",
  "__name__",
  "__package__",
  "__spec__"
]
```

Until now, these variables would show in the list of variables, but could lead to some confusion as some of them are related to the debugger implementation details (`ptvsd`).

This list can be seen as an equivalent to gitignore files, where users can choose which variables to hide and show.

In follow-up PRs, we can add a show / hide button to the Variables toolbar to toggle the variables directly. 

### TODO

- [x] Add variable filter to the settings
- [x] Filter variables from the tree and table

![filter-variables](https://user-images.githubusercontent.com/591645/74229117-089b8e00-4cc2-11ea-92fb-5356f4ee8364.gif)