### PR TITLE
Fix toggle button for JLab 2.0rc0

### DIFF
--- a/style/icons.css
+++ b/style/icons.css
@@ -109,7 +109,8 @@
   width: 35px;
 }
 
-.jp-Toolbar-item .jp-ToggleSwitch svg {
+.jp-Toolbar-item .jp-ToggleSwitch::before {
+  content: '';
   height: 10px;
   width: 10px;
   margin-left: 5px;
@@ -125,8 +126,8 @@
   background-color: var(--jp-warn-color0);
 }
 
-[data-jp-debugger='true'] .jp-Toolbar-item .jp-ToggleSwitch svg,
-[data-jp-table='true'] .jp-Toolbar-item .jp-ToggleSwitch svg {
+[data-jp-debugger='true'] .jp-Toolbar-item .jp-ToggleSwitch::before,
+[data-jp-table='true'] .jp-Toolbar-item .jp-ToggleSwitch::before {
   margin-left: 50%;
   margin-right: 5px;
 }


### PR DESCRIPTION
Fixes #361. 

This pretty much reverts the change for the toggle button CSS from https://github.com/jupyterlab/debugger/pull/337.

Relying on the inner `svg` element was not a robust solution anyway in the long run.

This seems to fix the issue with `2.0.0rc0`:

![toggle-button-rc-fix](https://user-images.githubusercontent.com/591645/74530709-08ea9200-4f2b-11ea-80e4-597804565f54.gif)
