### PR TITLE
Fix grey background for read-only editors

### DIFF
--- a/style/sources.css
+++ b/style/sources.css
@@ -1,4 +1,4 @@
-.jp-DebuggerSources-body [data-jp-debugger='true'].jp-Editor .jp-mod-readOnly {
+[data-jp-debugger='true'].jp-Editor .jp-mod-readOnly {
   background: var(--jp-layout-color2);
   height: 100%;
 }


### PR DESCRIPTION
Fixes #373.

![image](https://user-images.githubusercontent.com/591645/75666974-1451f300-5c77-11ea-8c1e-816d6bdaab9b.png)
