### PR TITLE
Use core lab caret icon for the tree view

### DIFF
--- a/src/variables/tree.tsx
+++ b/src/variables/tree.tsx
@@ -160,13 +160,12 @@ const VariableComponent = ({
 
   return (
     <li onClick={e => onVariableClicked(e)}>
-      {expandable && (
-        <caretDownEmptyIcon.react
-          stylesheet="menuItem"
-          tag="span"
-          transform={expanded ? 'rotate(0deg)' : 'rotate(-90deg)'}
-        />
-      )}
+      <caretDownEmptyIcon.react
+        visibility={expandable ? 'visible' : 'hidden'}
+        stylesheet="menuItem"
+        tag="span"
+        transform={expanded ? 'rotate(0deg)' : 'rotate(-90deg)'}
+      />
       <span style={styleName}>{variable.name}</span>
       <span>: </span>
       <span style={styleType}>{convertType(variable)}</span>

--- a/src/variables/tree.tsx
+++ b/src/variables/tree.tsx
@@ -1,13 +1,15 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ArrayExt } from '@lumino/algorithm';
-
-import { convertType } from '.';
-
 import { ReactWidget } from '@jupyterlab/apputils';
 
+import { caretDownEmptyIcon } from '@jupyterlab/ui-components';
+
+import { ArrayExt } from '@lumino/algorithm';
+
 import React, { useEffect, useState } from 'react';
+
+import { convertType } from '.';
 
 import { IDebugger } from '../tokens';
 
@@ -133,10 +135,6 @@ const VariableComponent = ({
   const [variable] = useState(data);
   const [expanded, setExpanded] = useState(null);
   const [details, setDetails] = useState(null);
-  const stylesCaret = {
-    transform: `rotate(90deg)`
-  };
-
   const styleName = {
     color: 'var(--jp-mirror-editor-attribute-color)'
   };
@@ -163,9 +161,11 @@ const VariableComponent = ({
   return (
     <li onClick={e => onVariableClicked(e)}>
       {expandable && (
-        <span className="caret" style={expanded ? stylesCaret : {}}>
-          ▶
-        </span>
+        <caretDownEmptyIcon.react
+          stylesheet="menuItem"
+          tag="span"
+          transform={expanded ? 'rotate(0deg)' : 'rotate(-90deg)'}
+        />
       )}
       <span style={styleName}>{variable.name}</span>
       <span>: </span>

--- a/style/variables.css
+++ b/style/variables.css
@@ -11,13 +11,21 @@
 .jp-DebuggerVariables-body ul {
   list-style: none;
   margin: 0;
-  padding: 0.5em;
+  padding: 0;
+}
+
+.jp-DebuggerVariables-body > ul {
+  padding-top: 0.1em;
 }
 
 .jp-DebuggerVariables-body ul li {
-  padding: 5px 0 5px 0;
+  padding: 5px 0 0 0;
   cursor: pointer;
   color: var(--jp-content-font-color1);
+}
+
+.jp-DebuggerVariables-body ul li > ul {
+  margin-left: 12px;
 }
 
 .jp-DebuggerVariables header .jp-Toolbar {

--- a/style/variables.css
+++ b/style/variables.css
@@ -15,17 +15,9 @@
 }
 
 .jp-DebuggerVariables-body ul li {
-  padding: 5px;
+  padding: 5px 0 5px 0;
   cursor: pointer;
   color: var(--jp-content-font-color1);
-}
-
-.jp-DebuggerVariables-body ul li .caret {
-  display: inline-block;
-  color: var(--jp-content-font-color2);
-  font-size: 12px;
-  margin-right: 3px;
-  user-select: none;
 }
 
 .jp-DebuggerVariables header .jp-Toolbar {


### PR DESCRIPTION
A quick pass on the tree view to tweak the CSS.

### Before

![image](https://user-images.githubusercontent.com/591645/76746501-e50fab80-6777-11ea-9232-92b7459bc73b.png)

### After

![image](https://user-images.githubusercontent.com/591645/76748840-c27f9180-677b-11ea-8f9c-1a3df76650c9.png)

### Changes

- [x] Use core lab caret icon for the tree view
- [x] Align items 