### PR TITLE
Add browser check to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Update conda
       run: conda update -y -n base conda setuptools
-    
+
     - name: Init conda
       run: |
         conda init bash
@@ -27,13 +27,19 @@ jobs:
       run: conda create -n jupyterlab-debugger --yes --quiet -c conda-forge nodejs jupyterlab=2 xeus-python=0.6.12 ptvsd python=$PYTHON_VERSION
       env:
         PYTHON_VERSION: '3.8'
-    
-    - name: Build the extension
+
+    - name: Build and install the extension
       run: |
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate jupyterlab-debugger
-        jlpm
-        jlpm run build
+        jlpm && jlpm run build
+        jupyter labextension link .
+
+    - name: Browser check
+      run: |
+        source "$CONDA/etc/profile.d/conda.sh"
+        conda activate jupyterlab-debugger
+        python -m jupyterlab.browser_check
 
     - name: Run the tests
       run: |

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -26,10 +26,13 @@ jobs:
     - name: Install the dependencies
       run: python -m pip install xeus-python==0.6.8 "jupyterlab>=2,<3" "notebook>=6,<7" ptvsd
 
-    - name: Build the extension
+    - name: Build and install the extension
       run: |
-        jlpm
-        jlpm run build
+        jlpm && jlpm run build
+        jupyter labextension link .
+
+    - name: Browser check
+      run: python -m jupyterlab.browser_check
 
     - name: Run the tests
       run: |


### PR DESCRIPTION
We can add the browser check step to CI, just like for other third-party extensions.

It is also now part of the default cookiecutter: 

https://github.com/jupyterlab/extension-cookiecutter-ts/blob/f33180f1c82bd6b310280d002d8a88f77005fcb9/.github/workflows/main.yml#L42