### PR TITLE
Filter _xpython-prefixed variables

### DIFF
--- a/schema/main.json
+++ b/schema/main.json
@@ -38,6 +38,9 @@
         "xpython": [
           "display",
           "ptvsd",
+          "_xpython_get_connection_filename",
+          "_xpython_launch",
+          "_pydev_stop_at_break",
           "__annotations__",
           "__builtins__",
           "__doc__",


### PR DESCRIPTION
Fixes #425. 

I am also removing `_pydev_stop_at_break` which was appearing in the general scope.

Note: this will already solve the issue for the OSX and Windows wheels which were published after we prefixed the variables with _xpython. Hence I think this can get in.