### PR TITLE
Extra typed breakpoints

### DIFF
--- a/src/breakpoints/body.tsx
+++ b/src/breakpoints/body.tsx
@@ -65,13 +65,15 @@ const BreakpointsComponent = ({ model }: { model: BreakpointsModel }) => {
 
   return (
     <>
-      {breakpoints.map(entry => (
-        <BreakpointCellComponent
-          key={entry[0]}
-          breakpoints={entry[1]}
-          model={model}
-        />
-      ))}
+      {breakpoints
+        .filter(find => find[0] === model.currentBreakpointsId)
+        .map(entry => (
+          <BreakpointCellComponent
+            key={entry[0]}
+            breakpoints={entry[1]}
+            model={model}
+          />
+        ))}
     </>
   );
 };

--- a/src/breakpoints/model.ts
+++ b/src/breakpoints/model.ts
@@ -14,7 +14,7 @@ export class BreakpointsModel implements IDisposable {
   /**
    * Get the last breakpoints from story
    */
-  get currentBreakpoinstId(): string {
+  get currentBreakpointsId(): string {
     return this._currentBreakpointsId;
   }
   /**

--- a/src/breakpoints/model.ts
+++ b/src/breakpoints/model.ts
@@ -12,6 +12,18 @@ import { IDebugger } from '../tokens';
  */
 export class BreakpointsModel implements IDisposable {
   /**
+   * Get the last breakpoints from story
+   */
+  get currentBreakpoinstId(): string {
+    return this._currentBreakpointsId;
+  }
+  /**
+   * Set the last breakpoints from story
+   */
+  set currentBreakpointsId(id: string) {
+    this._currentBreakpointsId = id;
+  }
+  /**
    * Whether the model is disposed.
    */
   get isDisposed(): boolean {
@@ -84,6 +96,8 @@ export class BreakpointsModel implements IDisposable {
     this._restored.emit();
   }
 
+  // actual id for breakpoints from story of them
+  private _currentBreakpointsId: string;
   private _isDisposed = false;
   private _breakpoints = new Map<string, IDebugger.IBreakpoint[]>();
   private _changed = new Signal<this, IDebugger.IBreakpoint[]>(this);

--- a/src/service.ts
+++ b/src/service.ts
@@ -326,6 +326,7 @@ export class DebuggerService implements IDebugger, IDisposable {
       const dumpedCell = await this.dumpCell(code);
       path = dumpedCell.sourcePath;
     }
+    this._model.breakpoints.currentBreakpointsId = path;
     const sourceBreakpoints = Private.toSourceBreakpoints(breakpoints);
     const reply = await this._setBreakpoints(sourceBreakpoints, path);
     let kernelBreakpoints = reply.body.breakpoints.map(breakpoint => {


### PR DESCRIPTION
Suggestion to solve the problem

EDIT:
I tried to refer to the suggestion in #414 

Sending an empty list by setBreakpont is not a good solution. We lose references when we want to change the breakpoint in the cell.

Every path (id) of breakpoints are actually a reference to the story of all breakpoints in focused, active cell.
What I did is showing the last element from history of them.

My solution would showing breakpoints from active cell. Additionally i have to do a trigger for active cell. 

Focus event is not good idea, because doesn't work when user click on breakpoint gutter. However I'll check it.

Next, what i should do is clearing story after a certain number of queries, because all of them stay on memory.

![Peek 2020-04-24 12-17](https://user-images.githubusercontent.com/45068804/80203508-8c111e00-8627-11ea-8343-d15fa57c1c45.gif)
