### PR TITLE
Add an editor-finder plugin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         conda init bash
         conda info -a
     - name: Create the conda environment
-      run: conda create -n jupyterlab-debugger --yes --quiet -c conda-forge nodejs jupyterlab=2 xeus-python=0.7.1 ptvsd python=$PYTHON_VERSION
+      run: conda create -n jupyterlab-debugger --yes --quiet -c conda-forge nodejs jupyterlab=2 xeus=0.23.14 xeus-python=0.7.1 ptvsd python=$PYTHON_VERSION
       env:
         PYTHON_VERSION: '3.8'
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A kernel with support for debugging is required to be able to use the debugger.
 It is generally recommended to create a new `conda` environment to install the dependencies:
 
 ```bash
-conda create -n jupyterlab-debugger -c conda-forge xeus-python=0.7.1 notebook=6 jupyterlab=2 ptvsd
+conda create -n jupyterlab-debugger -c conda-forge xeus=0.23.14 xeus-python=0.7.1 notebook=6 jupyterlab=2 ptvsd
 conda activate jupyterlab-debugger
 ```
 
@@ -49,7 +49,7 @@ Enable the debugger, set breakpoints and step into the code:
 
 ```bash
 # Create a new conda environment
-conda create -n jupyterlab-debugger -c conda-forge nodejs xeus-python=0.7.1 ptvsd jupyterlab=2
+conda create -n jupyterlab-debugger -c conda-forge nodejs xeus=0.23.14 xeus-python=0.7.1 ptvsd jupyterlab=2
 
 # Activate the conda environment
 conda activate jupyterlab-debugger

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,3 +8,4 @@ dependencies:
 - notebook=6
 - ptvsd
 - xeus-python=0.7.1
+- xeus=0.23.14

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -41,7 +41,7 @@ export namespace Debugger {
 
       const { callstackCommands, editorServices, service } = options;
 
-      this.model = new DebuggerModel();
+      this.model = service.model as DebuggerModel;
       this.service = service as DebuggerService;
       this.service.model = this.model;
 

--- a/src/editor-finder.ts
+++ b/src/editor-finder.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
 import {
@@ -18,6 +21,7 @@ import { IDebugger } from './tokens';
 export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
   constructor(options: EditorFinder.IOptions) {
     this._shell = options.shell;
+    this._debuggerService = options.debuggerService;
     this._notebookTracker = options.notebookTracker;
     this._consoleTracker = options.consoleTracker;
     this._editorTracker = options.editorTracker;
@@ -203,6 +207,11 @@ export namespace EditorFinder {
    * The options used to initialize a EditorFinder object.
    */
   export interface IOptions {
+    /**
+     * The debugger service.
+     */
+    debuggerService: IDebugger;
+
     /**
      * The editor services.
      */

--- a/src/editor-finder.ts
+++ b/src/editor-finder.ts
@@ -1,0 +1,244 @@
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
+import {
+  CodeEditor,
+  CodeEditorWrapper,
+  IEditorServices
+} from '@jupyterlab/codeeditor';
+import { IConsoleTracker } from '@jupyterlab/console';
+import { IEditorTracker } from '@jupyterlab/fileeditor';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { chain, each } from '@lumino/algorithm';
+import { IIterator } from '@lumino/algorithm/lib/iter';
+import { Token } from '@lumino/coreutils';
+import { IDisposable } from '@lumino/disposable';
+import { Signal } from '@lumino/signaling';
+import { IDebugger } from './tokens';
+
+export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
+  constructor(options: EditorFinder.IOptions) {
+    this._shell = options.shell;
+    this._notebookTracker = options.notebookTracker;
+    this._consoleTracker = options.consoleTracker;
+    this._editorTracker = options.editorTracker;
+    this._readOnlyEditorTracker = new WidgetTracker<
+      MainAreaWidget<CodeEditorWrapper>
+    >({
+      namespace: '@jupyterlab/debugger'
+    });
+  }
+
+  /**
+   * Whether the handler is disposed.
+   */
+  isDisposed: boolean;
+
+  /**
+   * Dispose the handler.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+    Signal.clearData(this);
+  }
+
+  /**
+   * Find the editor for a source matching the current debug session
+   * by iterating through all the widgets in each of the notebook,
+   * console, file editor, and read-only file editor trackers.
+   * @param debugSessionPath The path for the current debug session.
+   * @param source The source to find.
+   */
+  find(
+    debugSessionPath: string,
+    source: string
+  ): IIterator<CodeEditor.IEditor> {
+    return chain(
+      this._findInNotebooks(debugSessionPath, source),
+      this._findInConsoles(debugSessionPath, source),
+      this._findInEditors(debugSessionPath, source),
+      this._findInReadOnlyEditors(debugSessionPath, source)
+    );
+  }
+
+  /**
+   * Find the editor for a source matching the current debug session
+   * @param debugSessionPath The path for the current debug session.
+   * @param source The source to find.
+   */
+  private _findInNotebooks(debugSessionPath: string, source: string) {
+    if (!this._notebookTracker) {
+      return [];
+    }
+    const editors: CodeEditor.IEditor[] = [];
+    this._notebookTracker.forEach(notebookPanel => {
+      const sessionContext = notebookPanel.sessionContext;
+
+      if (sessionContext.path !== debugSessionPath) {
+        return;
+      }
+
+      const notebook = notebookPanel.content;
+      notebook.mode = 'command';
+      const cells = notebookPanel.content.widgets;
+      cells.forEach((cell, i) => {
+        // check the event is for the correct cell
+        const code = cell.model.value.text;
+        const cellId = this._debuggerService.getCodeId(code);
+        if (source !== cellId) {
+          return;
+        }
+        notebook.activeCellIndex = i;
+        const rect = notebook.activeCell.inputArea.node.getBoundingClientRect();
+        notebook.scrollToPosition(rect.bottom, 45);
+        editors.push(cell.editor);
+        this._shell.activateById(notebookPanel.id);
+      });
+    });
+    return editors;
+  }
+
+  /**
+   * Find the editor for a source matching the current debug session
+   * @param debugSessionPath The path for the current debug session.
+   * @param source The source to find.
+   */
+  private _findInConsoles(debugSessionPath: string, source: string) {
+    if (!this._consoleTracker) {
+      return [];
+    }
+    const editors: CodeEditor.IEditor[] = [];
+    this._consoleTracker.forEach(consoleWidget => {
+      const sessionContext = consoleWidget.sessionContext;
+
+      if (sessionContext.path !== debugSessionPath) {
+        return;
+      }
+
+      const cells = consoleWidget.console.cells;
+      each(cells, cell => {
+        const code = cell.model.value.text;
+        const codeId = this._debuggerService.getCodeId(code);
+        if (source !== codeId) {
+          return;
+        }
+        editors.push(cell.editor);
+        this._shell.activateById(consoleWidget.id);
+      });
+    });
+    return editors;
+  }
+
+  /**
+   * Find the editor for a source matching the current debug session
+   * from the editor tracker.
+   * @param debugSessionPath The path for the current debug session.
+   * @param source The source to find.
+   */
+  private _findInEditors(debugSessionPath: string, source: string) {
+    if (!this._editorTracker) {
+      return;
+    }
+    const editors: CodeEditor.IEditor[] = [];
+    this._editorTracker.forEach(doc => {
+      const fileEditor = doc.content;
+      if (debugSessionPath !== fileEditor.context.path) {
+        return;
+      }
+
+      const editor = fileEditor.editor;
+      if (!editor) {
+        return;
+      }
+
+      const code = editor.model.value.text;
+      const codeId = this._debuggerService.getCodeId(code);
+      if (source !== codeId) {
+        return;
+      }
+      editors.push(editor);
+      this._shell.activateById(doc.id);
+    });
+    return editors;
+  }
+
+  /**
+   * Find an editor for a source from the read-only editor tracker.
+   * @param source The source to find.
+   */
+  private _findInReadOnlyEditors(_: string, source: string) {
+    const editors: CodeEditor.IEditor[] = [];
+    this._readOnlyEditorTracker.forEach(widget => {
+      const editor = widget.content?.editor;
+      if (!editor) {
+        return;
+      }
+
+      const code = editor.model.value.text;
+      const codeId = this._debuggerService.getCodeId(code);
+      if (widget.title.caption !== source && source !== codeId) {
+        return;
+      }
+      editors.push(editor);
+      this._shell.activateById(widget.id);
+    });
+    return editors;
+  }
+  private _debuggerService: IDebugger;
+  private _shell: JupyterFrontEnd.IShell;
+  private _readOnlyEditorTracker: WidgetTracker<
+    MainAreaWidget<CodeEditorWrapper>
+  >;
+  private _notebookTracker: INotebookTracker | null;
+  private _consoleTracker: IConsoleTracker | null;
+  private _editorTracker: IEditorTracker | null;
+}
+/**
+ * A namespace for editor finder statics.
+ */
+export namespace EditorFinder {
+  /**
+   * The options used to initialize a EditorFinder object.
+   */
+  export interface IOptions {
+    /**
+     * The editor services.
+     */
+    editorServices: IEditorServices;
+
+    /**
+     * The application shell.
+     */
+    shell: JupyterFrontEnd.IShell;
+
+    /**
+     * An optional editor finder for notebooks.
+     */
+    notebookTracker?: INotebookTracker;
+
+    /**
+     * An optional editor finder for consoles.
+     */
+    consoleTracker?: IConsoleTracker;
+
+    /**
+     * An optional editor finder for file editors.
+     */
+    editorTracker?: IEditorTracker;
+  }
+  /**
+   * A token for a editor finder handler find method plugin
+   *
+   */
+}
+export const IDebuggerEditorFinder = new Token<IDebuggerEditorFinder>(
+  '@jupyterlab/debugger:editor-finder'
+);
+/**
+ * Interface for separated find method from editor finder plugin
+ */
+export interface IDebuggerEditorFinder {
+  find(debugSessionPath: string, source: string): IIterator<CodeEditor.IEditor>;
+}

--- a/src/editor-finder.ts
+++ b/src/editor-finder.ts
@@ -11,8 +11,7 @@ import {
 import { IConsoleTracker } from '@jupyterlab/console';
 import { IEditorTracker } from '@jupyterlab/fileeditor';
 import { INotebookTracker } from '@jupyterlab/notebook';
-import { chain, each } from '@lumino/algorithm';
-import { IIterator } from '@lumino/algorithm/lib/iter';
+import { chain, each, IIterator } from '@lumino/algorithm';
 import { Token } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { Signal } from '@lumino/signaling';

--- a/src/editor-finder.ts
+++ b/src/editor-finder.ts
@@ -21,7 +21,7 @@ import { IDebugger } from './tokens';
 export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
   constructor(options: EditorFinder.IOptions) {
     this._shell = options.shell;
-    this._debuggerService = options.debuggerService;
+    this._service = options.service;
     this._notebookTracker = options.notebookTracker;
     this._consoleTracker = options.consoleTracker;
     this._editorTracker = options.editorTracker;
@@ -90,7 +90,7 @@ export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
       cells.forEach((cell, i) => {
         // check the event is for the correct cell
         const code = cell.model.value.text;
-        const cellId = this._debuggerService.getCodeId(code);
+        const cellId = this._service.getCodeId(code);
         if (source !== cellId) {
           return;
         }
@@ -124,7 +124,7 @@ export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
       const cells = consoleWidget.console.cells;
       each(cells, cell => {
         const code = cell.model.value.text;
-        const codeId = this._debuggerService.getCodeId(code);
+        const codeId = this._service.getCodeId(code);
         if (source !== codeId) {
           return;
         }
@@ -158,7 +158,7 @@ export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
       }
 
       const code = editor.model.value.text;
-      const codeId = this._debuggerService.getCodeId(code);
+      const codeId = this._service.getCodeId(code);
       if (source !== codeId) {
         return;
       }
@@ -181,7 +181,7 @@ export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
       }
 
       const code = editor.model.value.text;
-      const codeId = this._debuggerService.getCodeId(code);
+      const codeId = this._service.getCodeId(code);
       if (widget.title.caption !== source && source !== codeId) {
         return;
       }
@@ -190,7 +190,7 @@ export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
     });
     return editors;
   }
-  private _debuggerService: IDebugger;
+  private _service: IDebugger;
   private _shell: JupyterFrontEnd.IShell;
   private _readOnlyEditorTracker: WidgetTracker<
     MainAreaWidget<CodeEditorWrapper>
@@ -208,9 +208,9 @@ export namespace EditorFinder {
    */
   export interface IOptions {
     /**
-     * The debugger service.
+     * An optional editor finder for consoles.
      */
-    debuggerService: IDebugger;
+    consoleTracker?: IConsoleTracker;
 
     /**
      * The editor services.
@@ -218,9 +218,9 @@ export namespace EditorFinder {
     editorServices: IEditorServices;
 
     /**
-     * The application shell.
+     * An optional editor finder for file editors.
      */
-    shell: JupyterFrontEnd.IShell;
+    editorTracker?: IEditorTracker;
 
     /**
      * An optional editor finder for notebooks.
@@ -228,14 +228,14 @@ export namespace EditorFinder {
     notebookTracker?: INotebookTracker;
 
     /**
-     * An optional editor finder for consoles.
+     * The debugger service.
      */
-    consoleTracker?: IConsoleTracker;
+    service: IDebugger;
 
     /**
-     * An optional editor finder for file editors.
+     * The application shell.
      */
-    editorTracker?: IEditorTracker;
+    shell: JupyterFrontEnd.IShell;
   }
   /**
    * A token for a editor finder handler find method plugin

--- a/src/editor-finder.ts
+++ b/src/editor-finder.ts
@@ -17,7 +17,14 @@ import { IDisposable } from '@lumino/disposable';
 import { Signal } from '@lumino/signaling';
 import { IDebugger } from './tokens';
 
-export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
+/**
+  * A class to find instances of code editors across notebook, console and files widgets
+  */
+ export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
+  /**
+   * Instantiate a new EditorFinder.
+   * @param options The instantiation options for a EditorFinder.
+   */
   constructor(options: EditorFinder.IOptions) {
     this._shell = options.shell;
     this._service = options.service;

--- a/src/editor-finder.ts
+++ b/src/editor-finder.ts
@@ -2,25 +2,35 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
+
 import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
+
 import {
   CodeEditor,
   CodeEditorWrapper,
   IEditorServices
 } from '@jupyterlab/codeeditor';
+
 import { IConsoleTracker } from '@jupyterlab/console';
+
 import { IEditorTracker } from '@jupyterlab/fileeditor';
+
 import { INotebookTracker } from '@jupyterlab/notebook';
+
 import { chain, each, IIterator } from '@lumino/algorithm';
+
 import { Token } from '@lumino/coreutils';
+
 import { IDisposable } from '@lumino/disposable';
+
 import { Signal } from '@lumino/signaling';
+
 import { IDebugger } from './tokens';
 
 /**
-  * A class to find instances of code editors across notebook, console and files widgets
-  */
- export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
+ * A class to find instances of code editors across notebook, console and files widgets
+ */
+export class EditorFinder implements IDisposable, IDebuggerEditorFinder {
   /**
    * Instantiate a new EditorFinder.
    * @param options The instantiation options for a EditorFinder.

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -205,7 +205,7 @@ export namespace TrackerHandler {
      */
     shell: JupyterFrontEnd.IShell;
     /**
-     * An optional editor finder
+     * The editor finder.
      */
     editorFinder: IDebuggerEditorFinder;
   }

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -207,7 +207,7 @@ export namespace TrackerHandler {
     /**
      * An optional editor finder
      */
-    editorFinder?: IDebuggerEditorFinder;
+    editorFinder: IDebuggerEditorFinder;
   }
 
   // TODO: move the interface and token below to token.ts?

--- a/src/handlers/tracker.ts
+++ b/src/handlers/tracker.ts
@@ -12,29 +12,21 @@ import {
   WidgetTracker
 } from '@jupyterlab/apputils';
 
-import {
-  CodeEditor,
-  CodeEditorWrapper,
-  IEditorServices
-} from '@jupyterlab/codeeditor';
-
-import { IConsoleTracker } from '@jupyterlab/console';
+import { CodeEditorWrapper, IEditorServices } from '@jupyterlab/codeeditor';
 
 import { PathExt } from '@jupyterlab/coreutils';
 
-import { IEditorTracker } from '@jupyterlab/fileeditor';
-
-import { INotebookTracker } from '@jupyterlab/notebook';
-
 import { textEditorIcon } from '@jupyterlab/ui-components';
 
-import { chain, each } from '@lumino/algorithm';
+import { each } from '@lumino/algorithm';
 
 import { Token } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
 
 import { Signal } from '@lumino/signaling';
+
+import { IDebuggerEditorFinder } from '../editor-finder';
 
 import { EditorHandler } from './editor';
 
@@ -59,10 +51,6 @@ export class TrackerHandler implements IDisposable {
   constructor(options: TrackerHandler.IOptions) {
     this._debuggerService = options.debuggerService;
     this._shell = options.shell;
-    this._notebookTracker = options.notebookTracker;
-    this._consoleTracker = options.consoleTracker;
-    this._editorTracker = options.editorTracker;
-
     this._readOnlyEditorFactory = new ReadOnlyEditorFactory({
       editorServices: options.editorServices
     });
@@ -73,6 +61,7 @@ export class TrackerHandler implements IDisposable {
       namespace: '@jupyterlab/debugger'
     });
 
+    this._editorFinder = options.editorFinder;
     this._onModelChanged();
     this._debuggerService.modelChanged.connect(this._onModelChanged, this);
   }
@@ -133,7 +122,7 @@ export class TrackerHandler implements IDisposable {
   ) {
     const debugSessionPath = this._debuggerService.session?.connection?.path;
     const source = frame?.source.path ?? null;
-    each(this._find(debugSessionPath, source), editor => {
+    each(this._editorFinder.find(debugSessionPath, source), editor => {
       requestAnimationFrame(() => {
         EditorHandler.showCurrentLine(editor, frame.line);
       });
@@ -151,7 +140,7 @@ export class TrackerHandler implements IDisposable {
     }
     const debugSessionPath = this._debuggerService.session.connection.path;
     const { content, mimeType, path } = source;
-    const results = this._find(debugSessionPath, path);
+    const results = this._editorFinder.find(debugSessionPath, path);
     if (results.next()) {
       return;
     }
@@ -183,149 +172,6 @@ export class TrackerHandler implements IDisposable {
       EditorHandler.showCurrentLine(editor, frame.line);
     }
   }
-
-  /**
-   * Find the editor for a source matching the current debug session
-   * by iterating through all the widgets in each of the notebook,
-   * console, file editor, and read-only file editor trackers.
-   * @param debugSessionPath The path for the current debug session.
-   * @param source The source to find.
-   */
-  private _find(debugSessionPath: string, source: string) {
-    return chain(
-      this._findInNotebooks(debugSessionPath, source),
-      this._findInConsoles(debugSessionPath, source),
-      this._findInEditors(debugSessionPath, source),
-      this._findInReadOnlyEditors(debugSessionPath, source)
-    );
-  }
-
-  /**
-   * Find the editor for a source matching the current debug session
-   * from the notebook tracker.
-   * @param debugSessionPath The path for the current debug session.
-   * @param source The source to find.
-   */
-  private _findInNotebooks(debugSessionPath: string, source: string) {
-    if (!this._notebookTracker) {
-      return [];
-    }
-    const editors: CodeEditor.IEditor[] = [];
-    this._notebookTracker.forEach(notebookPanel => {
-      const sessionContext = notebookPanel.sessionContext;
-
-      if (sessionContext.path !== debugSessionPath) {
-        return;
-      }
-
-      const notebook = notebookPanel.content;
-      notebook.mode = 'command';
-      const cells = notebookPanel.content.widgets;
-      cells.forEach((cell, i) => {
-        // check the event is for the correct cell
-        const code = cell.model.value.text;
-        const cellId = this._debuggerService.getCodeId(code);
-        if (source !== cellId) {
-          return;
-        }
-        notebook.activeCellIndex = i;
-        const rect = notebook.activeCell.inputArea.node.getBoundingClientRect();
-        notebook.scrollToPosition(rect.bottom, 45);
-        editors.push(cell.editor);
-        this._shell.activateById(notebookPanel.id);
-      });
-    });
-    return editors;
-  }
-
-  /**
-   * Find the editor for a source matching the current debug session
-   * from the console tracker.
-   * @param debugSessionPath The path for the current debug session.
-   * @param source The source to find.
-   */
-  private _findInConsoles(debugSessionPath: string, source: string) {
-    if (!this._consoleTracker) {
-      return [];
-    }
-    const editors: CodeEditor.IEditor[] = [];
-    this._consoleTracker.forEach(consoleWidget => {
-      const sessionContext = consoleWidget.sessionContext;
-
-      if (sessionContext.path !== debugSessionPath) {
-        return;
-      }
-
-      const cells = consoleWidget.console.cells;
-      each(cells, cell => {
-        const code = cell.model.value.text;
-        const codeId = this._debuggerService.getCodeId(code);
-        if (source !== codeId) {
-          return;
-        }
-        editors.push(cell.editor);
-        this._shell.activateById(consoleWidget.id);
-      });
-    });
-    return editors;
-  }
-
-  /**
-   * Find the editor for a source matching the current debug session
-   * from the editor tracker.
-   * @param debugSessionPath The path for the current debug session.
-   * @param source The source to find.
-   */
-  private _findInEditors(debugSessionPath: string, source: string) {
-    if (!this._editorTracker) {
-      return;
-    }
-    const editors: CodeEditor.IEditor[] = [];
-    this._editorTracker.forEach(doc => {
-      const fileEditor = doc.content;
-      if (debugSessionPath !== fileEditor.context.path) {
-        return;
-      }
-
-      const editor = fileEditor.editor;
-      if (!editor) {
-        return;
-      }
-
-      const code = editor.model.value.text;
-      const codeId = this._debuggerService.getCodeId(code);
-      if (source !== codeId) {
-        return;
-      }
-      editors.push(editor);
-      this._shell.activateById(doc.id);
-    });
-    return editors;
-  }
-
-  /**
-   * Find an editor for a source from the read-only editor tracker.
-   * @param source The source to find.
-   */
-  private _findInReadOnlyEditors(_: string, source: string) {
-    const editors: CodeEditor.IEditor[] = [];
-    this._readOnlyEditorTracker.forEach(widget => {
-      const editor = widget.content?.editor;
-      if (!editor) {
-        return;
-      }
-
-      const code = editor.model.value.text;
-      const codeId = this._debuggerService.getCodeId(code);
-      if (widget.title.caption !== source && source !== codeId) {
-        return;
-      }
-      editors.push(editor);
-      this._shell.activateById(widget.id);
-    });
-    return editors;
-  }
-
   private _debuggerService: IDebugger;
   private _debuggerModel: DebuggerModel;
   private _shell: JupyterFrontEnd.IShell;
@@ -333,9 +179,7 @@ export class TrackerHandler implements IDisposable {
   private _readOnlyEditorTracker: WidgetTracker<
     MainAreaWidget<CodeEditorWrapper>
   >;
-  private _notebookTracker: INotebookTracker | null;
-  private _consoleTracker: IConsoleTracker | null;
-  private _editorTracker: IEditorTracker | null;
+  private _editorFinder: IDebuggerEditorFinder | null;
 }
 
 /**
@@ -360,21 +204,10 @@ export namespace TrackerHandler {
      * The application shell.
      */
     shell: JupyterFrontEnd.IShell;
-
     /**
-     * An optional tracker for notebooks.
+     * An optional editor finder
      */
-    notebookTracker?: INotebookTracker;
-
-    /**
-     * An optional tracker for consoles.
-     */
-    consoleTracker?: IConsoleTracker;
-
-    /**
-     * An optional tracker for file editors.
-     */
-    editorTracker?: IEditorTracker;
+    editorFinder?: IDebuggerEditorFinder;
   }
 
   // TODO: move the interface and token below to token.ts?

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,9 @@ const tracker: JupyterFrontEndPlugin<void> = {
   }
 };
 
+/**
+ * A plugin that provides a debugger service.
+ */
 const service: JupyterFrontEndPlugin<IDebugger> = {
   id: '@jupyterlab/debugger:service',
   autoStart: true,
@@ -375,7 +378,7 @@ const variables: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * The main debuger UI plugin.
+ * The main debugger UI plugin.
  */
 const main: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/debugger:main',

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,19 +243,17 @@ const notebooks: JupyterFrontEndPlugin<void> = {
 /**
  * A plugin that tracks notebook, console and file editors used for debugging.
  */
-const tracker: JupyterFrontEndPlugin<TrackerHandler> = {
+const tracker: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/debugger:tracker',
   autoStart: true,
-  provides: IDebuggerEditorFinder,
-  requires: [IDebugger, IEditorServices],
-  optional: [INotebookTracker, IConsoleTracker, IEditorTracker],
+  requires: [IDebugger, IEditorServices, IDebuggerEditorFinder],
   activate: (
     app: JupyterFrontEnd,
     debug: IDebugger,
     editorServices: IEditorServices,
     editorFinder: IDebuggerEditorFinder
   ) => {
-    return new TrackerHandler({
+    new TrackerHandler({
       shell: app.shell,
       editorServices,
       debuggerService: debug,
@@ -267,26 +265,29 @@ const tracker: JupyterFrontEndPlugin<TrackerHandler> = {
 /**
  * A plugin that tracks editors, console and file editors used for debugging.
  */
-const finder: JupyterFrontEndPlugin<EditorFinder> = {
-  id: '@jupyterlab/debugger:tracker',
+const finder: JupyterFrontEndPlugin<IDebuggerEditorFinder> = {
+  id: '@jupyterlab/debugger:editor-finder',
   autoStart: true,
   provides: IDebuggerEditorFinder,
-  requires: [IEditorServices],
+  requires: [IDebugger, IEditorServices],
   optional: [INotebookTracker, IConsoleTracker, IEditorTracker],
   activate: (
     app: JupyterFrontEnd,
+    debuggerService: IDebugger,
     editorServices: IEditorServices,
-    notebookTracker: INotebookTracker,
-    consoleTracker: IConsoleTracker,
-    editorTracker: IEditorTracker
-  ) =>
-    new EditorFinder({
+    notebookTracker: INotebookTracker | null,
+    consoleTracker: IConsoleTracker | null,
+    editorTracker: IEditorTracker | null
+  ): IDebuggerEditorFinder => {
+    return new EditorFinder({
       shell: app.shell,
+      debuggerService,
       editorServices,
       notebookTracker,
       consoleTracker,
       editorTracker
-    })
+    });
+  }
 };
 /*
  * A plugin to open detailed views for variables.

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 
 import { Session } from '@jupyterlab/services';
 
+import { EditorFinder, IDebuggerEditorFinder } from './editor-finder';
+
 import {
   continueIcon,
   stepIntoIcon,
@@ -241,30 +243,51 @@ const notebooks: JupyterFrontEndPlugin<void> = {
 /**
  * A plugin that tracks notebook, console and file editors used for debugging.
  */
-const tracker: JupyterFrontEndPlugin<void> = {
+const tracker: JupyterFrontEndPlugin<TrackerHandler> = {
   id: '@jupyterlab/debugger:tracker',
   autoStart: true,
+  provides: IDebuggerEditorFinder,
   requires: [IDebugger, IEditorServices],
   optional: [INotebookTracker, IConsoleTracker, IEditorTracker],
   activate: (
     app: JupyterFrontEnd,
     debug: IDebugger,
     editorServices: IEditorServices,
-    notebookTracker: INotebookTracker,
-    consoleTracker: IConsoleTracker,
-    editorTracker: IEditorTracker
+    editorFinder: IDebuggerEditorFinder
   ) => {
-    new TrackerHandler({
+    return new TrackerHandler({
       shell: app.shell,
       editorServices,
       debuggerService: debug,
-      notebookTracker,
-      consoleTracker,
-      editorTracker
+      editorFinder
     });
   }
 };
 
+/**
+ * A plugin that tracks editors, console and file editors used for debugging.
+ */
+const finder: JupyterFrontEndPlugin<EditorFinder> = {
+  id: '@jupyterlab/debugger:tracker',
+  autoStart: true,
+  provides: IDebuggerEditorFinder,
+  requires: [IEditorServices],
+  optional: [INotebookTracker, IConsoleTracker, IEditorTracker],
+  activate: (
+    app: JupyterFrontEnd,
+    editorServices: IEditorServices,
+    notebookTracker: INotebookTracker,
+    consoleTracker: IConsoleTracker,
+    editorTracker: IEditorTracker
+  ) =>
+    new EditorFinder({
+      shell: app.shell,
+      editorServices,
+      notebookTracker,
+      consoleTracker,
+      editorTracker
+    })
+};
 /*
  * A plugin to open detailed views for variables.
  */
@@ -505,14 +528,14 @@ const main: JupyterFrontEndPlugin<IDebugger> = {
 /**
  * Export the plugins as default.
  */
-
 const plugins: JupyterFrontEndPlugin<any>[] = [
   consoles,
   files,
   notebooks,
   tracker,
   variables,
-  main
+  main,
+  finder
 ];
 
 export default plugins;

--- a/src/index.ts
+++ b/src/index.ts
@@ -396,7 +396,6 @@ const main: JupyterFrontEndPlugin<void> = {
     themeManager: IThemeManager | null
   ): Promise<void> => {
     const { commands, shell } = app;
-    console.log('editor finder', editorFinder);
 
     commands.addCommand(CommandIDs.debugContinue, {
       label: 'Continue',

--- a/src/service.ts
+++ b/src/service.ts
@@ -234,7 +234,25 @@ export class DebuggerService implements IDebugger, IDisposable {
         );
       });
     }
-
+    const unassociatedBreakpoints = (
+      fromServer: Map<string, IDebugger.IBreakpoint[]>,
+      fromNotebook: Map<string, IDebugger.IBreakpoint[]>
+    ) => {
+      let breakpointsOnlyOnServer: Array<string> = [];
+      for (let [key] of fromServer) {
+        if (!fromNotebook.has(key)) {
+          breakpointsOnlyOnServer.push(key);
+        }
+      }
+      return breakpointsOnlyOnServer;
+    };
+    for (const path of unassociatedBreakpoints(
+      bpMap,
+      this._model.breakpoints.breakpoints
+    )) {
+      bpMap.delete(path);
+      await this._setBreakpoints([], path);
+    }
     const stoppedThreads = new Set(reply.body.stoppedThreads);
     this._model.stoppedThreads = stoppedThreads;
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -234,25 +234,6 @@ export class DebuggerService implements IDebugger, IDisposable {
         );
       });
     }
-    const unassociatedBreakpoints = (
-      fromServer: Map<string, IDebugger.IBreakpoint[]>,
-      fromNotebook: Map<string, IDebugger.IBreakpoint[]>
-    ) => {
-      let breakpointsOnlyOnServer: Array<string> = [];
-      for (let [key] of fromServer) {
-        if (!fromNotebook.has(key)) {
-          breakpointsOnlyOnServer.push(key);
-        }
-      }
-      return breakpointsOnlyOnServer;
-    };
-    for (const path of unassociatedBreakpoints(
-      bpMap,
-      this._model.breakpoints.breakpoints
-    )) {
-      bpMap.delete(path);
-      await this._setBreakpoints([], path);
-    }
     const stoppedThreads = new Set(reply.body.stoppedThreads);
     this._model.stoppedThreads = stoppedThreads;
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -33,9 +33,7 @@ export class DebuggerService implements IDebugger, IDisposable {
     // TODO: also checks that the notebook or console
     // runs a kernel with debugging ability
     this._session = null;
-    // The model will be set by the UI which can be built
-    // after the service.
-    this._model = null;
+    this._model = new DebuggerModel();
   }
 
   /**


### PR DESCRIPTION
Refactor tracker.ts

Separated method find from tracker handler.
Created stand alone editor finder.

The plugin must be separated, instead of create the interface and token into tracker.ts, because if we don't do that will not be available in whole scope and will be a conflict with dependency cycle.