### PR TITLE
Update to TypeScript 3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
     "typedoc": "^0.15.4",
-    "typescript": "~3.7.3"
+    "typescript": "~3.9.2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
TypeScript 3.9 was released a couple days ago and a similar PR is currently open in the JupyterLab repo.

Blog post: https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/