### PR TITLE
Remove the temporary libgbm1 fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,6 @@ jobs:
         jlpm && jlpm run build
         jupyter labextension link .
 
-    - name: Install libgbm1 to fix puppeteer
-      run: sudo apt-get install libgbm1
-
     - name: Browser check
       run: |
         source "$CONDA/etc/profile.d/conda.sh"


### PR DESCRIPTION
We should now be able to remove the `libgbm1` fix that was added in https://github.com/jupyterlab/debugger/pull/428 to fix the browser check.