### PR TITLE
Remove unused start and stop command ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,10 +58,6 @@ import { VariablesBodyGrid } from './variables/grid';
  * The command IDs used by the debugger plugin.
  */
 export namespace CommandIDs {
-  export const start = 'debugger:start';
-
-  export const stop = 'debugger:stop';
-
   export const debugContinue = 'debugger:continue';
 
   export const terminate = 'debugger:terminate';


### PR DESCRIPTION
These are currently exported and available as `CommandIDs.start` and `CommandIDs.stop`, but not used for now.

Let's remove them and re-add back if / when needed.