### PR TITLE
Use the kernel spec metadata['debugger'] to check if a kernel supports debugging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -271,7 +271,8 @@ const service: JupyterFrontEndPlugin<IDebugger> = {
   id: '@jupyterlab/debugger:service',
   autoStart: true,
   provides: IDebugger,
-  activate: () => new DebuggerService()
+  activate: (app: JupyterFrontEnd) =>
+    new DebuggerService({ specsManager: app.serviceManager.kernelspecs })
 };
 
 /**

--- a/test/debugger.spec.ts
+++ b/test/debugger.spec.ts
@@ -5,6 +5,8 @@ import {
 
 import { JupyterServer } from '@jupyterlab/testutils';
 
+import { KernelSpecManager } from '@jupyterlab/services';
+
 import { CommandRegistry } from '@lumino/commands';
 
 import { Debugger } from '../src/debugger';
@@ -28,7 +30,8 @@ afterAll(async () => {
 });
 
 describe('Debugger', () => {
-  const service = new DebuggerService();
+  const specsManager = new KernelSpecManager();
+  const service = new DebuggerService({ specsManager });
   const registry = new CommandRegistry();
   const factoryService = new CodeMirrorEditorFactory();
   const mimeTypeService = new CodeMirrorMimeTypeService();

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -1,4 +1,4 @@
-import { Session } from '@jupyterlab/services';
+import { Session, KernelSpecManager } from '@jupyterlab/services';
 
 import {
   createSession,
@@ -28,7 +28,8 @@ afterAll(async () => {
 });
 
 describe('Debugging support', () => {
-  const service = new DebuggerService();
+  const specsManager = new KernelSpecManager();
+  const service = new DebuggerService({ specsManager });
   let xpython: Session.ISessionConnection;
   let ipykernel: Session.ISessionConnection;
 
@@ -65,6 +66,7 @@ describe('Debugging support', () => {
 });
 
 describe('DebuggerService', () => {
+  const specsManager = new KernelSpecManager();
   let connection: Session.ISessionConnection;
   let model: DebuggerModel;
   let session: IDebugger.ISession;
@@ -79,7 +81,7 @@ describe('DebuggerService', () => {
     await connection.changeKernel({ name: 'xpython' });
     session = new DebugSession({ connection });
     model = new DebuggerModel();
-    service = new DebuggerService();
+    service = new DebuggerService({ specsManager });
   });
 
   afterEach(async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// Utils from: https://github.com/jupyterlab/jupyterlab/blob/b1e2b83047421bf7196bec5f2a94d0616dcb2329/packages/services/test/utils.ts
+
+import { ServerConnection } from '@jupyterlab/services';
+
+import { JSONObject } from '@lumino/coreutils';
+
+export const KERNELSPECS: JSONObject = {
+  default: 'xpython',
+  kernelspecs: {
+    python3: {
+      name: 'Python',
+      spec: {
+        language: 'python',
+        argv: [],
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        display_name: 'Python 3',
+        env: {}
+      },
+      resources: {}
+    },
+    xpython: {
+      name: 'xpython',
+      spec: {
+        language: 'python',
+        argv: [],
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        display_name: 'xpython',
+        env: {},
+        metadata: { debugger: true }
+      },
+      resources: {}
+    }
+  }
+};
+
+/**
+ * Create new server connection settings.
+ *
+ * @param settings The server connection settings.
+ */
+export function makeSettings(
+  settings?: Partial<ServerConnection.ISettings>
+): ServerConnection.ISettings {
+  return ServerConnection.makeSettings(settings);
+}
+
+/**
+ * An interface for a service that has server settings.
+ */
+export interface IService {
+  readonly serverSettings: ServerConnection.ISettings;
+}
+
+/**
+ * Handle a single request with a mock response.
+ *
+ * @param item The service.
+ * @param status The status code for the response.
+ * @param body The body for the response.
+ */
+export function handleRequest(item: IService, status: number, body: any): void {
+  // Store the existing fetch function.
+  const oldFetch = item.serverSettings.fetch;
+
+  // A single use callback.
+  const temp = (info: RequestInfo, init: RequestInit): Promise<void> => {
+    // Restore fetch.
+    (item.serverSettings as any).fetch = oldFetch;
+
+    // Normalize the body.
+    if (typeof body !== 'string') {
+      body = JSON.stringify(body);
+    }
+
+    // Create the response and return it as a promise.
+    const response = new Response(body, { status });
+    return Promise.resolve(response as any);
+  };
+
+  // Override the fetch function.
+  (item.serverSettings as any).fetch = temp;
+}


### PR DESCRIPTION
Fixes #220. 
Alternative to #456 (see this comment: https://github.com/jupyterlab/debugger/pull/456#issuecomment-638072880)

The issue is that at the moment the `kernel_info_request` message is sent on the `shell` channel. If the execution has stopped (breakpoint hit), the debugger frontend forever waits for the `kernel_info_reply` to decide whether the kernel supports debugging or not, because the `debugger` key is in the kernel info reply.

Instead of waiting for the `kernel_info_reply`, the debugger frontend now checks the kernel spec to know if a kernel supports debugging or not.

~~This change requires the following change to the kernel spec, and the kernels (for now only xeus-python) would have to implement that change too:~~

**EDIT**: this has been added to `xeus-python=0.8.0` (https://github.com/jupyter-xeus/xeus-python/pull/282):

```
cat ${CONDA_PREFIX}/share/jupyter/kernels/xpython/kernel.json
```

```json
{
  "display_name": "xpython",
  "argv": [
      "/home/jtp/miniconda/envs/debugger/bin/xpython",
      "-f",
      "{connection_file}"
  ],
  "language": "python",
  "metadata": { "debugger": true }
}
```

Visually the result looks similar as in #456, except that there is no need for a timeout anymore:

![refresh-on-stopped-kernel-spec](https://user-images.githubusercontent.com/591645/84011946-1bc02100-a977-11ea-9ce2-386d1fe94a25.gif)

![refresh-on-stopped-5](https://user-images.githubusercontent.com/591645/83623484-ad075000-a591-11ea-8b2b-f5f45252ef14.gif)

This would also require an update to the sequence diagram in https://github.com/jupyterlab/debugger/issues/64.