### PR TITLE
Expand the sidebar on the initialized event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -384,14 +384,20 @@ const variables: JupyterFrontEndPlugin<void> = {
  */
 const main: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/debugger:main',
-  requires: [IDebugger, IEditorServices, IDebuggerEditorFinder],
-  optional: [ILayoutRestorer, ICommandPalette, ISettingRegistry, IThemeManager],
+  requires: [IDebugger, IEditorServices],
+  optional: [
+    ILabShell,
+    ILayoutRestorer,
+    ICommandPalette,
+    ISettingRegistry,
+    IThemeManager
+  ],
   autoStart: true,
   activate: async (
     app: JupyterFrontEnd,
     service: IDebugger,
     editorServices: IEditorServices,
-    editorFinder: IDebuggerEditorFinder,
+    labShell: ILabShell | null,
     restorer: ILayoutRestorer | null,
     palette: ICommandPalette | null,
     settingRegistry: ISettingRegistry | null,
@@ -506,8 +512,11 @@ const main: JupyterFrontEndPlugin<void> = {
       updateStyle();
     }
 
-    sidebar.service.eventMessage.connect(_ => {
+    sidebar.service.eventMessage.connect((_, event): void => {
       commands.notifyCommandChanged();
+      if (labShell && event.event === 'initialized') {
+        labShell.expandRight();
+      }
     });
 
     sidebar.service.sessionChanged.connect(_ => {


### PR DESCRIPTION
A small UX step towards https://github.com/jupyterlab/debugger/issues/289.

The sidebar is expanded when the `initialized` event is received, to let users know there is something on the right side:

![auto-expand-sidebar](https://user-images.githubusercontent.com/591645/83640794-ec8f6580-a5ac-11ea-82ac-37d24f029815.gif)
