### PR TITLE
Fix file editor toolbar CSS

### DIFF
--- a/style/console.css
+++ b/style/console.css
@@ -1,7 +1,0 @@
-.jp-ConsolePanel::before {
-  content: none;
-}
-
-.jp-ConsolePanel .jp-Toolbar {
-  justify-content: flex-end;
-}

--- a/style/index.css
+++ b/style/index.css
@@ -10,10 +10,6 @@
 @import './sidebar.css';
 @import './sources.css';
 
-.jp-Document .jp-Toolbar {
-  justify-content: flex-end;
-}
-
 .jp-left-truncated {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Fixes #477 

This change removes the styling applied to the document toolbar.

Since the toolbar is by default empty (although third-party extensions could add items), we might as well keep it at the start, the same for the console.

### Before

![image](https://user-images.githubusercontent.com/591645/86924283-8e1b5100-c12f-11ea-9b4b-3d1e48832f1f.png)

### After

![image](https://user-images.githubusercontent.com/591645/86924343-9ffcf400-c12f-11ea-9829-bfcc81224fde.png)
