### PR TITLE
Hide the sidebar if no kernel supports debugging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,18 @@ const main: JupyterFrontEndPlugin<void> = {
     settingRegistry: ISettingRegistry | null,
     themeManager: IThemeManager | null
   ): Promise<void> => {
-    const { commands, shell } = app;
+    const { commands, shell, serviceManager } = app;
+    const { kernelspecs } = serviceManager;
+
+    // hide the debugger sidebar if no kernel with support for debugging is available
+    await kernelspecs.ready;
+    const specs = kernelspecs.specs.kernelspecs;
+    const enabled = Object.keys(specs).some(
+      name => !!(specs[name].metadata?.['debugger'] ?? false)
+    );
+    if (!enabled) {
+      return;
+    }
 
     commands.addCommand(CommandIDs.debugContinue, {
       label: 'Continue',


### PR DESCRIPTION
Fixes #289.

![hide-sidebar](https://user-images.githubusercontent.com/591645/88210843-14b64f00-cc55-11ea-8b5e-c846f89de4e5.gif)
