### PR TITLE
Remove unnecessary uses of each()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,6 @@ import { Session } from '@jupyterlab/services';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
-import { each } from '@lumino/algorithm';
-
 import {
   continueIcon,
   stepIntoIcon,
@@ -555,19 +553,18 @@ const main: JupyterFrontEndPlugin<void> = {
         _: IDebugger.Model.ICallstack,
         frame: CallstackModel.IFrame
       ): void => {
-        each(
-          debuggerSources.find({
+        debuggerSources
+          .find({
             focus: true,
             kernel: service.session.connection.kernel.name,
             path: service.session?.connection?.path,
             source: frame?.source.path ?? null
-          }),
-          editor => {
+          })
+          .forEach(editor => {
             requestAnimationFrame(() => {
               EditorHandler.showCurrentLine(editor, frame.line);
             });
-          }
-        );
+          });
       };
 
       const onCurrentSourceOpened = (

--- a/src/service.ts
+++ b/src/service.ts
@@ -3,8 +3,6 @@
 
 import { Session, KernelSpec } from '@jupyterlab/services';
 
-import { each } from '@lumino/algorithm';
-
 import { IDisposable } from '@lumino/disposable';
 
 import { ISignal, Signal } from '@lumino/signaling';
@@ -461,19 +459,18 @@ export class DebuggerService implements IDebugger, IDisposable {
     for (const collection of breakpoints) {
       const [id, list] = collection;
       list.forEach(() => {
-        each(
-          this._debuggerSources.find({
+        this._debuggerSources
+          .find({
             focus: false,
             kernel: this.session.connection.kernel.name,
             path: this._session.connection.path,
             source: id
-          }),
-          () => {
+          })
+          .forEach(() => {
             if (list.length > 0) {
               bpMapForRestore.set(id, list);
             }
-          }
-        );
+          });
       });
     }
     return bpMapForRestore;


### PR DESCRIPTION
Since we return arrays in the sources find method, we can use native methods to iterate through the results.