### PR TITLE
Throw if the config does not have tmp file params

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,13 +16,19 @@ export class DebuggerConfig implements IDebugger.IConfig {
    * @param kernel The kernel name from current session.
    */
   getCodeId(code: string, kernel: string): string {
-    const { prefix, suffix } = this._fileParams.get(kernel);
+    const fileParams = this._fileParams.get(kernel);
+
+    if (!fileParams) {
+      throw new Error(`Kernel (${kernel}) has no tmp file params.`);
+    }
+
     const hash = this._hashMethods.get(kernel);
 
     if (!hash) {
       throw new Error(`Kernel (${kernel}) has no hashing params.`);
     }
 
+    const { prefix, suffix } = fileParams;
     return `${prefix}${hash(code)}${suffix}`;
   }
 

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -9,6 +9,15 @@ describe('DebuggerConfig', () => {
   });
 
   describe('#getCodeId', () => {
+    it('should compute a valid code id when the parameters are set', () => {
+      const [prefix, suffix] = ['foo', 'bar'];
+      config.setHashParams({ method: 'Murmur2', seed: 'bar', kernel });
+      config.setTmpFileParams({ prefix, suffix, kernel });
+      const codeId = config.getCodeId('i = 0', kernel);
+      expect(codeId.startsWith(prefix)).toBe(true);
+      expect(codeId.endsWith(suffix)).toBe(true);
+    });
+
     it('should throw if the kernel does not have hash parameters', () => {
       config.setTmpFileParams({ prefix: 'foo', suffix: 'bar', kernel });
       expect(() => {

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -1,0 +1,26 @@
+import { DebuggerConfig } from '../src/config';
+
+describe('DebuggerConfig', () => {
+  const kernel = 'python';
+  let config: DebuggerConfig;
+
+  beforeEach(() => {
+    config = new DebuggerConfig();
+  });
+
+  describe('#getCodeId', () => {
+    it('should throw if the kernel does not have hash parameters', () => {
+      config.setTmpFileParams({ prefix: 'foo', suffix: 'bar', kernel });
+      expect(() => {
+        config.getCodeId('i = 0', kernel);
+      }).toThrow('has no hashing params');
+    });
+
+    it('should throw if the kernel does not have tmp file parameters', () => {
+      config.setHashParams({ method: 'Murmur2', seed: 'bar', kernel });
+      expect(() => {
+        config.getCodeId('i = 0', kernel);
+      }).toThrow('has no tmp file params');
+    });
+  });
+});


### PR DESCRIPTION
Similar to the `hash` function look-up in the `DebuggerConfig`.

Since the `DebuggerConfig` relies on the caller to use `setTmpFileParams` and `setHashParams`, it can also throw an error if the tmp file parameters are not set.

This change also adds basic unit tests for the `DebuggerConfig`.