### PR TITLE
Switch to SourceBreakpoint for the debugInfo response

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -560,7 +560,7 @@ export class DebuggerService implements IDebugger, IDisposable {
         const { breakpoints, source } = val;
         map.set(
           source,
-          breakpoints.map(point => ({ ...point, active: true }))
+          breakpoints.map(point => ({ ...point, verified: true, active: true }))
         );
         return map;
       },

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -435,7 +435,7 @@ export namespace IDebugger {
      */
     export interface IDebugInfoBreakpoints {
       source: string;
-      breakpoints: DebugProtocol.Breakpoint[];
+      breakpoints: DebugProtocol.SourceBreakpoint[];
     }
 
     /**


### PR DESCRIPTION
cc @JohanMabille @SylvainCorlay @afshin 

The kernel *should* return an array of `DebugProtocol.SourceBreakpoint`: https://microsoft.github.io/debug-adapter-protocol/specification#Types_SourceBreakpoint

But the frontend was specifying a `DebugProtocol.Breakpoint` as the response type.