### PR TITLE
Remove active from IDebugger.IBreakpoint

### DIFF
--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -330,7 +330,6 @@ namespace Private {
   ): IDebugger.IBreakpoint {
     return {
       line,
-      active: true,
       verified: true,
       source: {
         name: session

--- a/src/service.ts
+++ b/src/service.ts
@@ -371,9 +371,9 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     // Set the kernel's breakpoints for this path.
     const reply = await this._setBreakpoints(localBreakpoints, path);
-    const updatedBreakpoints = reply.body.breakpoints
-      .map(val => ({ ...val, active: true }))
-      .filter((val, _, arr) => arr.findIndex(el => el.line === val.line) > -1);
+    const updatedBreakpoints = reply.body.breakpoints.filter(
+      (val, _, arr) => arr.findIndex(el => el.line === val.line) > -1
+    );
 
     // Update the local model and finish kernel configuration.
     this._model.breakpoints.setBreakpoints(path, updatedBreakpoints);
@@ -558,10 +558,7 @@ export class DebuggerService implements IDebugger, IDisposable {
         val: IDebugger.ISession.IDebugInfoBreakpoints
       ) => {
         const { breakpoints, source } = val;
-        map.set(
-          source,
-          breakpoints.map(point => ({ ...point, active: true }))
-        );
+        map.set(source, breakpoints);
         return map;
       },
       new Map<string, IDebugger.IBreakpoint[]>()

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -167,9 +167,7 @@ export namespace IDebugger {
   /**
    * Single breakpoint in an editor.
    */
-  export interface IBreakpoint extends DebugProtocol.Breakpoint {
-    active: boolean;
-  }
+  export interface IBreakpoint extends DebugProtocol.Breakpoint {}
 
   /**
    * Debugger file and hashing configuration.

--- a/test/debugger.spec.ts
+++ b/test/debugger.spec.ts
@@ -115,7 +115,6 @@ describe('Debugger', () => {
       return {
         id,
         line,
-        active: true,
         verified: true,
         source: {
           path
@@ -221,7 +220,6 @@ describe('Debugger', () => {
         {
           id: 3,
           line: 4,
-          active: true,
           verified: true,
           source: {
             path

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -184,7 +184,6 @@ describe('DebuggerService', () => {
         return {
           id: index,
           line: l,
-          active: true,
           verified: true,
           source: {
             path: sourceId


### PR DESCRIPTION
Fixes #515. 

Since this functionality is not implemented (frontend and backend), we can remove it from the interfaces.