### PR TITLE
Make kernelspecs optional for DebuggerService

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -147,6 +147,9 @@ export class DebuggerService implements IDebugger, IDisposable {
    * @param connection The session connection.
    */
   async isAvailable(connection: Session.ISessionConnection): Promise<boolean> {
+    if (!this._specsManager) {
+      return true;
+    }
     await this._specsManager.ready;
     const kernel = connection?.kernel;
     if (!kernel) {
@@ -665,13 +668,13 @@ export namespace DebuggerService {
     config: IDebugger.IConfig;
 
     /**
-     * The kernel specs manager.
-     */
-    specsManager: KernelSpec.IManager;
-
-    /**
-     * The debugger sources instance.
+     * The optional debugger sources instance.
      */
     debuggerSources?: IDebugger.ISources;
+
+    /**
+     * The optional kernel specs manager.
+     */
+    specsManager?: KernelSpec.IManager;
   }
 }


### PR DESCRIPTION
This was brought in: https://github.com/jupyterlab/debugger/pull/457#discussion_r434455064

If `kernelSpecs` is not provided to the `DebuggerService`, then it is assumed that debugging is enabled, and the call to `DebuggerServicer#isAvailable` returns true regardless of the kernel connection passed as the argument.

This change should make it easier for users of `DebuggerService` in custom frontends and lab builds to enable debugging by default if they want to. 