### PR TITLE
Return true from DebuggerServicer#isAvailable when spec is not available

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -157,7 +157,7 @@ export class DebuggerService implements IDebugger, IDisposable {
     }
     const name = kernel.name;
     if (!this._specsManager.specs.kernelspecs[name]) {
-        return true;
+      return true;
     }
     return !!(
       this._specsManager.specs.kernelspecs[name].metadata?.['debugger'] ?? false

--- a/src/service.ts
+++ b/src/service.ts
@@ -156,6 +156,9 @@ export class DebuggerService implements IDebugger, IDisposable {
       return false;
     }
     const name = kernel.name;
+    if (!this._specsManager.specs.kernelspecs[name]) {
+        return true;
+    }
     return !!(
       this._specsManager.specs.kernelspecs[name].metadata?.['debugger'] ?? false
     );


### PR DESCRIPTION
This is a followup to: https://github.com/jupyterlab/debugger/pull/518

Returning `true` when calling `DebuggerServicer#isAvailable` and the `this._specsManager.specs.kernelspecs` are not available for the current kernel.
