### PR TITLE
Rename IDebugger tokens

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -726,18 +726,18 @@ export namespace IDebugger {
 /**
  * The visual debugger token.
  */
-export const IDebugger = new Token<IDebugger>('@jupyterlab/debugger');
+export const IDebugger = new Token<IDebugger>('@jupyterlab/debugger:IDebugger');
 
 /**
  * The debugger configuration token.
  */
 export const IDebuggerConfig = new Token<IDebugger.IConfig>(
-  '@jupyterlab/debugger:config'
+  '@jupyterlab/debugger:IDebuggerConfig'
 );
 
 /**
  * The debugger sources utility token.
  */
 export const IDebuggerSources = new Token<IDebugger.ISources>(
-  '@jupyterlab/debugger:sources'
+  '@jupyterlab/debugger:IDebuggerSources'
 );


### PR DESCRIPTION
To follow the same convention as for the core plugins.

This was noticed while looking at the plugin dependency graph:

![image](https://user-images.githubusercontent.com/591645/88722677-f3a79f80-d127-11ea-8ce6-aa4de796b29b.png)
