### PR TITLE
Add page config override for debugger panel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -397,13 +397,10 @@ const main: JupyterFrontEndPlugin<void> = {
     const { kernelspecs } = serviceManager;
 
     // First check if there is a PageConfig override for the extension visibility
-    const showDebuggerExtension = String(
-      PageConfig.getOption('showDebuggerExtension')
-    ).toLowerCase();
-    if (showDebuggerExtension === 'false') {
-      return;
-    }
-    if (showDebuggerExtension !== 'true') {
+    const alwaysShowDebuggerExtension =
+      PageConfig.getOption('alwaysShowDebuggerExtension').toLowerCase() ===
+      'true';
+    if (!alwaysShowDebuggerExtension) {
       // hide the debugger sidebar if no kernel with support for debugging is available
       await kernelspecs.ready;
       const specs = kernelspecs.specs.kernelspecs;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { IEditorServices } from '@jupyterlab/codeeditor';
 
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 
-import { PathExt } from '@jupyterlab/coreutils';
+import { PageConfig, PathExt } from '@jupyterlab/coreutils';
 
 import { DocumentWidget } from '@jupyterlab/docregistry';
 
@@ -396,14 +396,23 @@ const main: JupyterFrontEndPlugin<void> = {
     const { commands, shell, serviceManager } = app;
     const { kernelspecs } = serviceManager;
 
-    // hide the debugger sidebar if no kernel with support for debugging is available
-    await kernelspecs.ready;
-    const specs = kernelspecs.specs.kernelspecs;
-    const enabled = Object.keys(specs).some(
-      name => !!(specs[name].metadata?.['debugger'] ?? false)
-    );
-    if (!enabled) {
+    // First check if there is a PageConfig override for the extension visibility
+    const showDebuggerExtension = String(
+      PageConfig.getOption('showDebuggerExtension')
+    ).toLowerCase();
+    if (showDebuggerExtension === 'false') {
       return;
+    }
+    if (showDebuggerExtension !== 'true') {
+      // hide the debugger sidebar if no kernel with support for debugging is available
+      await kernelspecs.ready;
+      const specs = kernelspecs.specs.kernelspecs;
+      const enabled = Object.keys(specs).some(
+        name => !!(specs[name].metadata?.['debugger'] ?? false)
+      );
+      if (!enabled) {
+        return;
+      }
     }
 
     commands.addCommand(CommandIDs.debugContinue, {


### PR DESCRIPTION
Related to https://github.com/jupyterlab/debugger/issues/526

Adding PageConfig override to enable / disable the debugger extension.

If the override is set to true: enable the extension without checking kernel specs.
If the override is set to false: disable the extension.
If the override is not set: check the specs to determine whether or not the extension should be enabled.