### PR TITLE
Condition for empty string

### DIFF
--- a/src/handlers/editor.ts
+++ b/src/handlers/editor.ts
@@ -218,7 +218,7 @@ export class EditorHandler implements IDisposable {
   private _getBreakpoints(): IDebugger.IBreakpoint[] {
     const code = this._editor.model.value.text;
     return this._debuggerService.model.breakpoints.getBreakpoints(
-      this._path ?? this._debuggerService.getCodeId(code)
+      this._path || this._debuggerService.getCodeId(code)
     );
   }
 


### PR DESCRIPTION
Solution for problem with setting and removing breakpoints. Condition has been changed for case with empty string of `the_path`