### PR TITLE
Show the toolbar button before restoring the state

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -292,8 +292,8 @@ export class DebuggerHandler {
         : null;
       this._service.session.connection = connection;
     }
-    await this._service.restoreState(false);
     addToolbarButton();
+    await this._service.restoreState(false);
 
     // check the state of the debug session
     if (!this._service.isStarted) {


### PR DESCRIPTION
Given a kernel that supports debugging, this change switches the order of the two following actions:

- restore the state using the `debugInfo` request
- add the button to the notebook toolbar

This makes it easier for kernel authors that are progressively implementing the protocol to see that the kernel is correctly supported by the debugger extension.

Otherwise we would wait for the response here:

https://github.com/jupyterlab/debugger/blob/9de87f02b5ee9403cf9c11bb276898e955a21e62/src/handler.ts#L295

And never show the button.

With this change, the button can be displayed in the toolbar:

![image](https://user-images.githubusercontent.com/591645/92914976-6943a280-f42c-11ea-91e8-84d6bab036c1.png)

Even though the `debugInfo` request has not been implemented yet:

![image](https://user-images.githubusercontent.com/591645/92915024-7791be80-f42c-11ea-98ad-041665df2206.png)
