### PR TITLE
Do not minimize on Binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,2 @@
-jupyter labextension install @jupyterlab/debugger@0.3.2 --debug
+jupyter labextension install @jupyterlab/debugger@0.3.2 --debug --no-build
+jupyter lab build --minimize=False


### PR DESCRIPTION
Looks like recent versions of JupyterLab 2.x fail to build on Binder due to high memory consumption.

Turning off minimization should help make the build succeed.

https://mybinder.org/v2/gh/jupyterlab/debugger/binder-minimize-false?urlpath=/lab/tree/examples/index.ipynb