### PR TITLE
Add get_ipython to the variable filter

### DIFF
--- a/schema/main.json
+++ b/schema/main.json
@@ -37,6 +37,7 @@
       "default": {
         "xpython": [
           "display",
+          "get_ipython",
           "ptvsd",
           "_xpython_get_connection_filename",
           "_xpython_launch",


### PR DESCRIPTION
Fixes #499 

Will port to https://github.com/jupyterlab/jupyterlab right after.