### PR TITLE
v0.3.3

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,2 @@
-jupyter labextension install @jupyterlab/debugger@0.3.2 --debug --no-build
+jupyter labextension install @jupyterlab/debugger@0.3.3 --debug --no-build
 jupyter lab build --minimize=False

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/debugger",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "JupyterLab - Debugger Extension",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Tagging as `0.3.x` as the changes from https://github.com/jupyterlab/debugger/pull/533 are considered backward compatible.