### PR TITLE
Switch to a different murmurhash implementation to handle Unicode characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A kernel with support for debugging is required to be able to use the debugger.
 It is generally recommended to create a new `conda` environment to install the dependencies:
 
 ```bash
-conda create -n jupyterlab-debugger -c conda-forge xeus-python=0.8.0 notebook=6 jupyterlab=2 ptvsd nodejs
+conda create -n jupyterlab-debugger -c conda-forge xeus-python=0.8.6 notebook=6 jupyterlab=2 ptvsd nodejs
 conda activate jupyterlab-debugger
 ```
 
@@ -49,7 +49,7 @@ Enable the debugger, set breakpoints and step into the code:
 
 ```bash
 # Create a new conda environment
-conda create -n jupyterlab-debugger -c conda-forge nodejs xeus-python=0.8.0 ptvsd jupyterlab=2
+conda create -n jupyterlab-debugger -c conda-forge nodejs xeus-python=0.8.6 ptvsd jupyterlab=2
 
 # Activate the conda environment
 conda activate jupyterlab-debugger

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,4 +7,4 @@ dependencies:
 - nodejs
 - notebook=6
 - ptvsd
-- xeus-python=0.8.0
+- xeus-python=0.8.6

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,8 @@ let local = {
   transform: {
     '\\.(ts|tsx)?$': 'ts-jest',
     '\\.svg$': 'jest-raw-loader'
-  }
+  },
+  testEnvironment: './test/custom-env'
 };
 
 Object.keys(local).forEach(option => {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@lumino/datagrid": "^0.6.0",
     "@lumino/disposable": "^1.2.0",
     "@lumino/widgets": "^1.8.0",
-    "murmurhash2": "^0.1.0",
     "vscode-debugprotocol": "^1.37.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@lumino/datagrid": "^0.6.0",
     "@lumino/disposable": "^1.2.0",
     "@lumino/widgets": "^1.8.0",
-    "murmurhash-js": "^1.0.0",
+    "murmurhash2": "^0.1.0",
     "vscode-debugprotocol": "^1.37.0"
   },
   "devDependencies": {
@@ -80,7 +80,6 @@
     "@jupyterlab/testutils": "^2.2.0",
     "@types/codemirror": "0.0.76",
     "@types/jest": "^24.0.17",
-    "@types/murmurhash-js": "1.0.3",
     "@types/react-dom": "^16.9.8",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { murmur2 } from 'murmurhash-js';
+import { murmur2 } from 'murmurhash2';
 
 import { IDebugger } from './tokens';
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { murmur2 } from 'murmurhash2';
+import { murmur2 } from './hash';
 
 import { IDebugger } from './tokens';
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// Most of the implementation below is adapted from the following repository:
+// https://github.com/garycourt/murmurhash-js/blob/master/murmurhash2_gc.js
+// Which has the following MIT License:
+//
+// Copyright (c) 2011 Gary Court
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// The implementation below uses case fallthrough as part of the algorithm.
+/* eslint-disable no-fallthrough */
+
+const m = 0x5bd1e995;
+const encoder = new TextEncoder();
+
+/**
+ * Calculate the murmurhash2 for a given string and seed.
+ *
+ * @param str The string to calculate the Murmur2 hash for.
+ * @param seed The seed.
+ *
+ * @returns The Murmurhash2 hash.
+ */
+export function murmur2(str: string, seed: number): number {
+  const data = encoder.encode(str);
+  let len = data.length;
+  let h = seed ^ len;
+  let i = 0;
+
+  while (len >= 4) {
+    let k =
+      (data[i] & 0xff) |
+      ((data[++i] & 0xff) << 8) |
+      ((data[++i] & 0xff) << 16) |
+      ((data[++i] & 0xff) << 24);
+
+    k = (k & 0xffff) * m + ((((k >>> 16) * m) & 0xffff) << 16);
+    k ^= k >>> 24;
+    k = (k & 0xffff) * m + ((((k >>> 16) * m) & 0xffff) << 16);
+
+    h = ((h & 0xffff) * m + ((((h >>> 16) * m) & 0xffff) << 16)) ^ k;
+
+    len -= 4;
+    ++i;
+  }
+
+  switch (len) {
+    case 3:
+      h ^= (data[i + 2] & 0xff) << 16;
+    case 2:
+      h ^= (data[i + 1] & 0xff) << 8;
+    case 1:
+      h ^= data[i] & 0xff;
+      h = (h & 0xffff) * m + ((((h >>> 16) * m) & 0xffff) << 16);
+  }
+
+  h ^= h >>> 13;
+  h = (h & 0xffff) * m + ((((h >>> 16) * m) & 0xffff) << 16);
+  h ^= h >>> 15;
+
+  return h >>> 0;
+}

--- a/test/custom-env.js
+++ b/test/custom-env.js
@@ -1,0 +1,16 @@
+// See: https://github.com/facebook/jest/issues/9983
+
+const Environment = require('jest-environment-jsdom');
+
+module.exports = class CustomTestEnvironment extends Environment {
+  /**
+   *
+   */
+  async setup() {
+    await super.setup();
+    if (typeof this.global.TextEncoder === 'undefined') {
+      const { TextEncoder } = require('util');
+      this.global.TextEncoder = TextEncoder;
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5255,11 +5255,6 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-murmurhash2@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/murmurhash2/-/murmurhash2-0.1.0.tgz#ace6cecc699080d63b9d856ce6593a9d07d445b7"
-  integrity sha512-k/0g4jE/NRCRqjTeZOzZOfjXs/TqXuV6yl6RfXApoi0io7K7oOJXQ217OymoNDLksmrhCvzcDi/Yj1wOnA57xQ==
-
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,11 +1791,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/murmurhash-js@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/murmurhash-js/-/murmurhash-js-1.0.3.tgz#0e8c0a1db692c062ea4f7e1093fc1ba1d1839298"
-  integrity sha512-PxJwTlcFOBRPqv9pSoC3O1FpKN8GnM5hMJIkG6U3omH8b4GAh28fO1c+TMR4oxj0BG43/ICbrIK3KBfzad2heg==
-
 "@types/node@*":
   version "14.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.23.tgz#676fa0883450ed9da0bb24156213636290892806"
@@ -5260,10 +5255,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-murmurhash-js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
-  integrity sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=
+murmurhash2@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/murmurhash2/-/murmurhash2-0.1.0.tgz#ace6cecc699080d63b9d856ce6593a9d07d445b7"
+  integrity sha512-k/0g4jE/NRCRqjTeZOzZOfjXs/TqXuV6yl6RfXApoi0io7K7oOJXQ217OymoNDLksmrhCvzcDi/Yj1wOnA57xQ==
 
 mute-stream@0.0.8:
   version "0.0.8"


### PR DESCRIPTION
Fixes #538.

This change switches to using the murmurhash2 implementation from: https://github.com/jtpio/murmurhash2

### Before

![unicode-before](https://user-images.githubusercontent.com/591645/95508189-e540f400-09b2-11eb-9e53-a13d9e5615b1.gif)

### After

![unicode-after](https://user-images.githubusercontent.com/591645/95508199-e7a34e00-09b2-11eb-8676-74c24379d3e9.gif)

### The issue

Here is a report after digging into this and looking for different solutions. Posting a bit of information here so it's more convenient to refer to it in the future.

In https://github.com/jupyterlab/debugger/issues/538, we noticed that having non-ascii characters such as `€` in a code cell could be reproduced on the stable Binder (using `0.3.3`).

It was because the MurmurHash2 implementation in JS and the one used in `xeus-python` would not give the same result for the same input and seed.

`@jupyterlab/debugger` was using this implementation: https://github.com/mikolalysenko/murmurhash-js/blob/f19136e9f9c17f8cddc216ca3d44ec7c5c502f60/murmurhash2_gc.js#L14-L50, which corresponds to the version published on npm: https://www.npmjs.com/package/murmurhash-js 

`xeus-python` is using this implementation: https://github.com/xtensor-stack/xtl/blob/7d41f768787ee6405e3f1b1056e04f6fbd43f8cd/include/xtl/xhash.hpp#L47
Which is based on the original in C++: https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp

Using this code snippet:

```python
print("€")
```

With `3339675911` as the seed.

Would give:

- `murmurhash-js`: `3511777296`
- `xtl`: `1079235191`

(more info in #538)

Summary:

![image](https://user-images.githubusercontent.com/591645/95611343-fe54ae00-0a61-11eb-911f-0e036360e426.png)


From here two options:

**WebAssemly**

This sounds attractive because it would mean using the same code on both the backend and the frontend.
Reviving the initial work from https://github.com/xtensor-stack/xtl/pull/171 led to being able to use the `murmur2_x86` function in a node repl.  

However it started to feel a bit complicated when:

- instantiating WebAssembly on the web seems to be async only as of today. This would have to be taken into consideration when importing and loading the library, so the methods can be called when the instance is ready.
- packaging `.wasm` files for the web as part of an npm package is a bit complicated. At least as of today, but it might improve over time
- one option for packaging the wasm as js is to `base64` encode it, and create a new `Uint8Array` to be passed to `WebAssembly.initiate` in a `setup` hook / function or equivalent
- the bundle size from compiling `xtl/hash` to wasm with `emscripten` is in the order of ~100KB, which is quite a lot for just one function
- the `emscripten` / wasm tooling requires extra setup

**Fix the existing JS implementation**

The implementation from `murmurhash-js` states it is for ascii strings only: https://github.com/garycourt/murmurhash-js/blob/0197ce38bedac0e05f40b9d7152095d06db8292c/murmurhash2_gc.js#L9

Instead, we can convert the string to a `Uint8Array` via a `TextEncoder`, and perform the operations on the `Uint8Array` just like the original algorithm and the one used in `xeus-python`.
This is implemented in https://github.com/jtpio/murmurhash2

### Additional thoughts

Instead of having yet another `murmurhash2` package on npm, one way forward could be to move [the implementation](https://github.com/jtpio/murmurhash2/blob/0be3d062f024310dceba29d541469b8f67ef4bc9/src/index.ts) to [`@jupyterlab/coreutils`](https://github.com/jtpio/murmurhash2/blob/01a8ebc37164f7206abeb69a302c05ed5e233560/src/index.ts) instead.

The `0.3.x` releases of the debugger extension (this repo) could still depend on [`murmur2`](https://www.npmjs.com/package/murmurhash2).