### PR TITLE
Add an archive header to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Archived
 
-**This project is archived. Development is now happening in https://github.com/jupyerlab/jupyterlab**.
+**This project is archived. Development is now happening in https://github.com/jupyterlab/jupyterlab**.
 
 **If you use JupyterLab 3.x:**
 
@@ -11,12 +11,12 @@ The debugger extension is shipped by default with JupyterLab 3.x and doesn't nee
 Be sure to install a kernel that supports debugging, such as `xeus-python`:
 
 ```bash
-conda install -c conda-forge xeus-python ptvsd
+conda install -c conda-forge xeus-python
 ```
 
 Refer to the documentation for more details: https://jupyterlab.readthedocs.io/en/latest/user/debugger.html
 
-Please open new issues and pull requests on the JupyterLab repo: https://github.com/jupyerlab/jupyterlab
+Please open new issues and pull requests on the JupyterLab repo: https://github.com/jupyterlab/jupyterlab
 
 **If you use JupyterLab 2.x:**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,27 @@
 
 ## Archived
 
-**This project is archived. Development is now happening in https://github.com/jupyerlab/jupyterlab**
+**This project is archived. Development is now happening in https://github.com/jupyerlab/jupyterlab**.
+
+**If you use JupyterLab 3.x:**
+
+The debugger extension is shipped by default with JupyterLab 3.x and doesn't need to be installed manually.
+
+Be sure to install a kernel that supports debugging, such as `xeus-python`:
+
+```bash
+conda install -c conda-forge xeus-python ptvsd
+```
+
+Refer to the documentation for more details: https://jupyterlab.readthedocs.io/en/latest/user/debugger.html
+
+Please open new issues and pull requests on the JupyterLab repo: https://github.com/jupyerlab/jupyterlab
+
+**If you use JupyterLab 2.x:**
+
+Follow the [instructions below](https://github.com/jupyterlab/debugger#installation).
+
+---
 
 ![Github Actions Status](https://github.com/jupyterlab/debugger/workflows/Tests/badge.svg)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/debugger/stable?urlpath=/lab/tree/examples/index.ipynb)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # @jupyterlab/debugger
 
+## Archived
+
+**This project is archived. Development is now happening in https://github.com/jupyerlab/jupyterlab**
+
 ![Github Actions Status](https://github.com/jupyterlab/debugger/workflows/Tests/badge.svg)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/debugger/stable?urlpath=/lab/tree/examples/index.ipynb)
-[![npm](https://img.shields.io/npm/v/@jupyterlab/debugger.svg)](https://www.npmjs.com/package/@jupyterlab/debugger)
 
 A JupyterLab debugger UI extension. This extension is under active development.
 


### PR DESCRIPTION
Fixes #536. 

Mention that the repo is archived.

## TODO

- [x] Mention that development is happening in https://github.com/jupyerlab/jupyterlab
- [x] Add a note that `@jupyterlab/debugger@0.3.x` is compatible with JupyterLab 2.x, and next versions of `@jupyterlab/debugger` and `@jupyterlab/debugger-extension` are for JupyterLab 3+