### PR TITLE
Updated xeus-python version

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,4 +7,4 @@ dependencies:
 - nodejs
 - notebook=6
 - ptvsd
-- xeus-python=0.8.0
+- xeus-python=0.8.6


### PR DESCRIPTION
I think xeus-python 0.8.0 is outdated. I opened an issue (#551) on this one which I closed as soon as I figured out it's an xeus-python issue, not debugger's. 